### PR TITLE
Adding zcount support and spec

### DIFF
--- a/src/main/scala/com/redis/SortedSetOperations.scala
+++ b/src/main/scala/com/redis/SortedSetOperations.scala
@@ -74,4 +74,9 @@ trait SortedSetOperations { self: Redis =>
   def zunionstoreWeighted(dstKey: Any, kws: Iterable[Product2[Any,Double]], aggregate: Aggregate = SUM)(implicit format: Format): Option[Int] =
     send("ZUNIONSTORE", (Iterator(dstKey, kws.size) ++ kws.iterator.map(_._1) ++ Iterator.single("WEIGHTS") ++ kws.iterator.map(_._2) ++ Iterator("AGGREGATE", aggregate)).toList)(asInt)
 
+  // ZCOUNT
+  //
+  def zcount(key: Any, min: Double = Double.NegativeInfinity, max: Double = Double.PositiveInfinity, minInclusive: Boolean = true, maxInclusive: Boolean = true)(implicit format: Format): Option[Int] =
+    send("ZCOUNT", List(key, Format.formatDouble(min, minInclusive), Format.formatDouble(max, maxInclusive)))(asInt)
+
 }

--- a/src/main/scala/com/redis/cluster/RedisCluster.scala
+++ b/src/main/scala/com/redis/cluster/RedisCluster.scala
@@ -232,6 +232,8 @@ abstract class RedisCluster(hosts: String*) extends RedisClient {
     nodeForKey(key).zrangeWithScore[A](key, start, end, sortAs)
   override def zrangebyscore[A](key: Any, min: Double = Double.NegativeInfinity, minInclusive: Boolean = true, max: Double = Double.PositiveInfinity, maxInclusive: Boolean = true, limit: Option[(Int, Int)])(implicit format: Format, parse: Parse[A]) =
     nodeForKey(key).zrangebyscore[A](key, min, minInclusive, max, maxInclusive, limit)
+  override def zcount(key: Any, min: Double = Double.NegativeInfinity, max: Double = Double.PositiveInfinity, minInclusive: Boolean = true, maxInclusive: Boolean = true)(implicit format: Format): Option[Int] =
+    nodeForKey(key).zcount(key, min, max, minInclusive, maxInclusive)
 
   /**
    * HashOperations

--- a/src/test/scala/com/redis/SortedSetOperationsSpec.scala
+++ b/src/test/scala/com/redis/SortedSetOperationsSpec.scala
@@ -97,4 +97,12 @@ class SortedSetOperationsSpec extends Spec
       zrangeWithScore("hackers weighted").get.map(_._2.toInt) should equal(List(1953, 1965, 3832, 3938, 5820, 7648))
     }
   }
+  
+  describe("zcount") {
+    it ("should return the number of elements between min and max") {
+      add
+      
+      zcount("hackers", 1912, 1920) should equal(Some(2))
+    }
+  }
 }


### PR DESCRIPTION
I didn't see support for the sorted set ZCOUNT command (http://redis.io/commands/zcount) so I added that and a spec.
