### PR TITLE
Removed some printlns in the pubsub trait

### DIFF
--- a/src/main/scala/com/redis/PubSub.scala
+++ b/src/main/scala/com/redis/PubSub.scala
@@ -36,11 +36,9 @@ trait PubSub { self: Redis =>
             msgType match {
               case "subscribe" | "psubscribe" => fn(S(channel, data.toInt))
               case "unsubscribe" if (data.toInt == 0) => 
-                println("for break")
                 fn(U(channel, data.toInt))
                 break
               case "punsubscribe" if (data.toInt == 0) => 
-                println("for break")
                 fn(U(channel, data.toInt))
                 break
               case "unsubscribe" | "punsubscribe" => 


### PR DESCRIPTION
I noticed these when testing out the pubsub stuff. They are fine in the specs but I don't need them in my app's logs :)
