### PR TITLE
publish command should return number of clients per protocol

### DIFF
--- a/src/main/scala/com/redis/PubSub.scala
+++ b/src/main/scala/com/redis/PubSub.scala
@@ -96,7 +96,7 @@ trait PubSub { self: Redis =>
     send("UNSUBSCRIBE", channel :: channels.toList)(())
   }
 
-  def publish(channel: String, msg: String) = {
-    send("PUBLISH", List(channel, msg))(())
+  def publish(channel: String, msg: String): Option[Int] = {
+    send("PUBLISH", List(channel, msg))(asInt)
   }
 }

--- a/src/test/scala/com/redis/PubSubSpec.scala
+++ b/src/test/scala/com/redis/PubSubSpec.scala
@@ -65,5 +65,21 @@ class PubSubSpec extends Spec
         }
       }
     }
+
+    it("should publish without breaking the other commands afterwards") {
+      t.set("key", "value")
+
+      t.get("key") match {
+        case Some(s: String) => s should equal("value")
+        case None => fail("should return value")
+      }
+
+      t.publish("a", "message")
+
+      t.get("key") match {
+        case Some(s: String) => s should equal("value")
+        case None => fail("should return value")
+      }
+    }
   }
 }


### PR DESCRIPTION
publish command should return number of clients who have received a msg, ignoring it was causing protocol error for every command after that. UT is provided
