### PR TITLE
Made StackObjectPool's maxIdle parameter configurable in RedisClientPool

### DIFF
--- a/src/main/scala/com/redis/Pool.scala
+++ b/src/main/scala/com/redis/Pool.scala
@@ -21,8 +21,8 @@ private [redis] class RedisClientFactory(host: String, port: Int) extends Poolab
   def activateObject(rc: RedisClient): Unit = {}
 }
 
-class RedisClientPool(host: String, port: Int) {
-  val pool = new StackObjectPool(new RedisClientFactory(host, port))
+class RedisClientPool(host: String, port: Int, maxIdle: Int = 8) {
+  val pool = new StackObjectPool(new RedisClientFactory(host, port), maxIdle)
   override def toString = host + ":" + String.valueOf(port)
 
   def withClient[T](body: RedisClient => T) = {


### PR DESCRIPTION
The commit message says it all, but trying to explain better: 

I was using RedisClientPool in a environment with 24 threads heavily using Redis (and doing other stuff). The problem is that, as maxIdle of StackObjectPool defaults to 8, when more than 8 objects were borrowed and then returned to the pool, this maxIdle threshold was hit. As ~24 objects are borrowed but pool only maintains up to 8 idle objects. That means that every time an object is returned and there is more than 8 idle objects in the pool, the bottom object in the stack pool is destroyed. Then causing a gigantic destroy-create-destroy-create cycle. As the number of Sockets being opened and closed to Redis increased, I guess, it also exhausted the ephemeral port range giving the error:

```
java.lang.RuntimeException: java.net.NoRouteToHostException: Cannot assign requested address
```

Changing the maxIdle parameter to 30 stopped all the problems. I've also check in the Redis log that a huge number of connections were being dropped and accepted again and again and again.
