### PR TITLE
Doesn't receive pmessage

### DIFF
--- a/src/main/scala/com/redis/PubSub.scala
+++ b/src/main/scala/com/redis/PubSub.scala
@@ -45,7 +45,13 @@ trait PubSub { self: Redis =>
                   break
                 case "unsubscribe" | "punsubscribe" => 
                   fn(U(channel, data.toInt))
-                case "message" | "pmessage" => 
+                case "message" =>
+                  fn(M(channel, data))
+                case x => throw new RuntimeException("unhandled message: " + x)
+              }
+            case Some(Some(msgType) :: Some(pattern) :: Some(channel) :: List(Some(data))) =>
+              msgType match {
+                case "pmessage" =>
                   fn(M(channel, data))
                 case x => throw new RuntimeException("unhandled message: " + x)
               }


### PR DESCRIPTION
I try to receive some message from redis, but couldn't receive message.

``` scala
  val client = new RedisClient("localhost", 6379)
  client.pSubscribe("*") { pubsub => println(pubsub) }
```

```
S(*,1)
```

Now working after a fixed code.
I'm using a redis version 2.4.17.
