### PR TITLE
added incrbyfloat operation

### DIFF
--- a/src/main/scala/com/redis/RedisProtocol.scala
+++ b/src/main/scala/com/redis/RedisProtocol.scala
@@ -127,6 +127,7 @@ private [redis] trait R extends Reply {
 
   def asInt: Option[Int] =  receive(integerReply orElse queuedReplyInt)
   def asLong: Option[Long] =  receive(longReply orElse queuedReplyLong)
+  def asDouble: Option[Double] = asBulk[Double](Parse.Implicits.parseDouble)
 
   def asBoolean: Boolean = receive(integerReply orElse singleLineReply) match {
     case Some(n: Int) => n > 0

--- a/src/main/scala/com/redis/StringOperations.scala
+++ b/src/main/scala/com/redis/StringOperations.scala
@@ -37,6 +37,11 @@ trait StringOperations { self: Redis =>
   def incrby(key: Any, increment: Int)(implicit format: Format): Option[Long] =
     send("INCRBY", List(key, increment))(asLong)
 
+  // INCRBYFLOAT (key, increment)
+  // increments the specified key by increment
+  def incrbyfloat(key: Any, increment: Double)(implicit format: Format): Option[Double] =
+    send("INCRBYFLOAT", List(key, increment))(asDouble)
+
   // DECR (key)
   // decrements the specified key by 1
   def decr(key: Any)(implicit format: Format): Option[Long] =

--- a/src/test/scala/com/redis/StringOperationsSpec.scala
+++ b/src/test/scala/com/redis/StringOperationsSpec.scala
@@ -1,8 +1,6 @@
 package com.redis
 
-import org.scalatest.FunSpec
-import org.scalatest.BeforeAndAfterEach
-import org.scalatest.BeforeAndAfterAll
+import org.scalatest.{OptionValues, FunSpec, BeforeAndAfterEach, BeforeAndAfterAll}
 import org.scalatest.matchers.ShouldMatchers
 import org.scalatest.junit.JUnitRunner
 import org.junit.runner.RunWith
@@ -12,7 +10,8 @@ import org.junit.runner.RunWith
 class StringOperationsSpec extends FunSpec 
                            with ShouldMatchers
                            with BeforeAndAfterEach
-                           with BeforeAndAfterAll {
+                           with BeforeAndAfterAll
+                           with OptionValues {
 
   val r = new RedisClient("localhost", 6379)
 
@@ -113,6 +112,19 @@ class StringOperationsSpec extends FunSpec
       try {
         r.incrby("anshin-4", 5)
       } catch { case ex: Throwable => ex.getMessage should startWith("ERR value is not an integer") }
+    }
+  }
+
+  describe("incrbyfloat") {
+    it ("should increment by 0.1 for a key that contains a float") {
+      r.set("anshin-1", 9.9)
+      r.incrbyfloat("anshin-1", 0.1f).value should be (10.0 plusOrMinus 0.0000001)
+    }
+    it ("should reset to 0 and then increment by 0.1 for a key that contains a diff type") {
+      r.set("anshin-4", "debasish") should equal(true)
+      try {
+        r.incrbyfloat("anshin-4", 0.1)
+      } catch { case ex: Throwable => ex.getMessage should startWith("ERR value is not a valid float") }
     }
   }
 


### PR DESCRIPTION
Added incrbyfloat operation, see: http://redis.io/commands/incrbyfloat

Somehow needed to explicitly pass the parseDouble, should be implicit. Might need a bit of refactoring.

Also added OptionValues trait to StringOperationsSpec for easier testing of options.
