### PR TITLE
Benchmark : Ops done should not be multiplied by 2

### DIFF
--- a/src/test/scala/com/redis/Bench.scala
+++ b/src/test/scala/com/redis/Bench.scala
@@ -34,7 +34,7 @@ object Bench {
     val tasks = (1 to 100) map (i => actors.Futures.future { fn(opsPerClient, "k" + i.toString) })
     val results = tasks map (future => future.apply())
     val elapsedSeconds = (System.nanoTime - start)/1000000000.0 
-    val opsPerSec = (opsPerClient * 100 * 2) / elapsedSeconds
+    val opsPerSec = (opsPerClient * 100) / elapsedSeconds
     (elapsedSeconds, opsPerSec, results)
   }
 }


### PR DESCRIPTION
Maybe i am wrong, but i don't understand where "2" come from ?
