### PR TITLE
Sentinel support

### DIFF
--- a/src/main/scala/com/redis/NodeAddress.scala
+++ b/src/main/scala/com/redis/NodeAddress.scala
@@ -1,0 +1,100 @@
+package com.redis
+
+import java.net.InetSocketAddress
+
+abstract class NodeAddress {
+  def addr: (String, Int)
+
+  def onChange(callback: InetSocketAddress => Unit)
+  override def toString = {
+    val (host, port) = addr
+    host + ":" + String.valueOf(port)
+  }
+}
+
+class FixedAddress(host: String, port: Int) extends NodeAddress {
+  val addr = (host, port)
+  override def onChange(callback: InetSocketAddress => Unit) { }
+}
+
+class SentinelMonitoredMasterAddress(val sentinels: Seq[(String, Int)], val masterName: String) extends NodeAddress
+  with Log {
+
+  var master: Option[(String, Int)] = None
+
+  override def addr = master.synchronized {
+    master match {
+      case Some((h, p)) => (h, p)
+      case _ => throw new RuntimeException("All sentinels are down.")
+    }
+  }
+
+  private var onChangeCallbacks: List[InetSocketAddress => Unit] = Nil
+
+  override def onChange(callback: InetSocketAddress => Unit) = synchronized {
+    onChangeCallbacks = callback :: onChangeCallbacks
+  }
+
+  private def fireCallbacks(addr: InetSocketAddress) = synchronized {
+    onChangeCallbacks foreach (_(addr))
+  }
+
+  def stopMonitoring() {
+    sentinelListeners foreach (_.stop())
+  }
+
+  private val sentinelClients = sentinels.map { case (h, p) =>
+    val client = new SentinelClient(h, p)
+    master match { // this can be done without synchronization because the threads are not yet live
+      case Some(_) =>
+      case None =>
+        try {
+          master = client.getMasterAddrByName(masterName)
+        } catch {
+          case e: Throwable => error("Error connecting to sentinel.", e)
+        }
+    }
+    client
+  }
+  private val sentinelListeners = sentinelClients map { client =>
+    val listener = new SentinelListener(client)
+    new Thread(listener).start()
+    listener
+  }
+
+  private class SentinelListener(val client: SentinelClient) extends Runnable {
+    @volatile var running: Boolean = false
+
+    def run() {
+      running = true
+      while (running) {
+        try {
+          client.synchronized {
+            client.send("SUBSCRIBE", List("+switch-master"))(())
+          }
+          new client.Consumer((msg: PubSubMessage) =>
+            msg match {
+              case M(chan, msgText) =>
+                val tokens = msgText split ' '
+                val addr = tokens(3)
+                val port = tokens(4).toInt
+                master.synchronized {
+                  master = Some(addr, port)
+                }
+                fireCallbacks(new InetSocketAddress(addr, port))
+              case _ =>
+          }).run() // synchronously read, so we know when a disconnect happens
+        } catch {
+          case e: Throwable => error("Error connecting to sentinel.", e)
+        }
+      }
+    }
+
+    def stop() {
+      client.synchronized {
+        client.unsubscribe
+      }
+      running = false
+    }
+  }
+}

--- a/src/main/scala/com/redis/Pool.scala
+++ b/src/main/scala/com/redis/Pool.scala
@@ -4,12 +4,12 @@ import org.apache.commons.pool._
 import org.apache.commons.pool.impl._
 import com.redis.cluster.ClusterNode
 
-private [redis] class RedisClientFactory(val host: String, val port: Int, val database: Int = 0, val secret: Option[Any] = None) 
+private [redis] class RedisClientFactory(val addr: NodeAddress, val database: Int = 0, val secret: Option[Any] = None)
   extends PoolableObjectFactory[RedisClient] {
 
   // when we make an object it's already connected
   def makeObject = {
-    val cl = new RedisClient(host, port)
+    val cl = new RedisClient(addr)
     if (database != 0)
       cl.select(database)
     secret.foreach(cl auth _)
@@ -30,9 +30,15 @@ private [redis] class RedisClientFactory(val host: String, val port: Int, val da
   def activateObject(rc: RedisClient): Unit = {}
 }
 
-class RedisClientPool(val host: String, val port: Int, val maxIdle: Int = 8, val database: Int = 0, val secret: Option[Any] = None) {
-  val pool = new StackObjectPool(new RedisClientFactory(host, port, database, secret), maxIdle)
-  override def toString = host + ":" + String.valueOf(port)
+class RedisClientPool(val addr: NodeAddress, val maxIdle: Int = 8, val database: Int = 0, val secret: Option[Any] = None) {
+  def host: String = addr.addr._1
+  def port: Int = addr.addr._2
+
+  def this(host: String, port: Int) =
+    this(new FixedAddress(host, port))
+
+  val pool = new StackObjectPool(new RedisClientFactory(addr, database, secret), maxIdle)
+  override def toString = addr.toString
 
   def withClient[T](body: RedisClient => T) = {
     val client = pool.borrowObject
@@ -52,6 +58,6 @@ class RedisClientPool(val host: String, val port: Int, val maxIdle: Int = 8, val
  * @param poolname must be unique
  */
 class IdentifiableRedisClientPool(val node: ClusterNode)
-  extends RedisClientPool (node.host, node.port, node.maxIdle, node.database, node.secret){
+  extends RedisClientPool (new FixedAddress(node.host, node.port), node.maxIdle, node.database, node.secret) {
   override def toString = node.nodename
 }

--- a/src/main/scala/com/redis/RedisClient.scala
+++ b/src/main/scala/com/redis/RedisClient.scala
@@ -57,11 +57,12 @@ trait RedisCommand extends Redis
   with EvalOperations
   
 
-class RedisClient(override val host: String, override val port: Int)
+class RedisClient(val addr: NodeAddress)
   extends RedisCommand with PubSub {
 
   connect
 
+  def this(host: String, port: Int) = this(new FixedAddress(host, port))
   def this() = this("localhost", 6379)
   override def toString = host + ":" + String.valueOf(port)
 
@@ -153,8 +154,7 @@ class RedisClient(override val host: String, override val port: Int)
       null.asInstanceOf[A]
     }
 
-    val host = parent.host
-    val port = parent.port
+    lazy val addr = parent.addr
 
     // TODO: Find a better abstraction
     override def connected = parent.connected

--- a/src/main/scala/com/redis/SentinelClient.scala
+++ b/src/main/scala/com/redis/SentinelClient.scala
@@ -1,0 +1,15 @@
+package com.redis
+
+class SentinelClient(override val host: String, override val port: Int) extends Redis
+  with SentinelOperations
+  with PubSub {
+
+  lazy val addr: NodeAddress = new FixedAddress(host, port) // can only be fixed, not a dynamic master
+
+  def this() = this("localhost", 26379)
+  override def toString = host + ":" + String.valueOf(port)
+
+  // publishing is not allowed on a sentinel's pub/sub channel
+  override def publish(channel: String, msg: String): Option[Long] =
+    throw new RuntimeException("Publishing is not supported on a sentinel.")
+}

--- a/src/main/scala/com/redis/SentinelOperations.scala
+++ b/src/main/scala/com/redis/SentinelOperations.scala
@@ -1,0 +1,32 @@
+package com.redis
+
+import serialization._
+
+trait SentinelOperations { self: Redis =>
+
+  def masters[K,V](implicit format: Format, parseK: Parse[K], parseV: Parse[V]): Option[List[Option[Map[K,V]]]] =
+    send("SENTINEL", List("MASTERS"))(asListOfListPairs[K,V].map(_.map(_.map(_.flatten.toMap))))
+
+  def slaves[K,V](name: String)(implicit format: Format, parseK: Parse[K], parseV: Parse[V]):
+      Option[List[Option[Map[K,V]]]] =
+    send("SENTINEL", List("SLAVES", name))(asListOfListPairs[K,V].map(_.map(_.map(_.flatten.toMap))))
+
+  def isMasterDownByAddr(host: String, port: Int): Option[(Boolean, String)] =
+    send("SENTINEL", List("IS-MASTER-DOWN-BY-ADDR", host, port))(asList) match {
+      case Some(List(Some(down), Some(leader))) => Some(down.toInt == 1, leader)
+      case _ => None
+    }
+
+  def getMasterAddrByName(name: String): Option[(String, Int)] =
+    send("SENTINEL", List("GET-MASTER-ADDR-BY-NAME", name))(asList[String]) match {
+      case Some(List(Some(h), Some(p))) => Some(h, p.toInt)
+      case _ => None
+    }
+
+  def reset(pattern: String): Option[Int] =
+    send("SENTINEL", List("RESET", pattern))(asInt)
+
+  def failover(name: String): Boolean =
+    send("SENTINEL", List("FAILOVER", name))(asBoolean)
+
+}

--- a/src/main/scala/com/redis/cluster/RedisCluster.scala
+++ b/src/main/scala/com/redis/cluster/RedisCluster.scala
@@ -67,8 +67,7 @@ case class ClusterNode(nodename: String, host: String, port: Int, database: Int 
 abstract class RedisCluster(hosts: ClusterNode*) extends RedisCommand {
 
   // not needed at cluster level
-  override val host = null
-  override val port = 0
+  lazy val addr = new FixedAddress(null, 0)
 
   // abstract val
   val keyTag: Option[KeyTag]

--- a/src/main/scala/com/redis/cluster/RedisShards.scala
+++ b/src/main/scala/com/redis/cluster/RedisShards.scala
@@ -14,8 +14,7 @@ import scala.util.matching.Regex
 abstract class RedisShards(val hosts: List[ClusterNode]) extends RedisCommand {
 
   // not needed at cluster level
-  override val host = null
-  override val port = 0
+  lazy val addr = new FixedAddress(null, 0)
 
   // abstract val
   val keyTag: Option[KeyTag]

--- a/src/main/scala/com/redis/ds/Deque.scala
+++ b/src/main/scala/com/redis/ds/Deque.scala
@@ -73,13 +73,13 @@ abstract class RedisDeque[A](val blocking: Boolean = false, val timeoutInSecs: I
   }
 }
 
-import com.redis.{Redis, ListOperations}
+import com.redis.{Redis, ListOperations, NodeAddress, FixedAddress}
 
-class RedisDequeClient(val h: String, val p: Int) {
+class RedisDequeClient(val a: NodeAddress) {
+  def this(h: String, p: Int) = this(new FixedAddress(h, p))
   def getDeque[A](k: String, blocking: Boolean = false, timeoutInSecs: Int = 0)(implicit format: Format, parse: Parse[A]) =
     new RedisDeque(blocking, timeoutInSecs)(format, parse) with ListOperations with Redis {
-      val host = h
-      val port = p
+      lazy val addr = a
       val key = k
       connect
     }

--- a/src/test/scala/com/redis/SentinelOperationsSpec.scala
+++ b/src/test/scala/com/redis/SentinelOperationsSpec.scala
@@ -1,0 +1,127 @@
+package com.redis
+
+import org.scalatest.{OptionValues, BeforeAndAfterAll, BeforeAndAfterEach, FunSpec}
+import org.scalatest.matchers.ShouldMatchers
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class SentinelOperationsSpec extends FunSpec
+  with ShouldMatchers
+  with BeforeAndAfterEach
+  with BeforeAndAfterAll
+  with OptionValues {
+
+  val hosts = List(("localhost", 6379), ("localhost", 6380), ("localhost", 6381), ("localhost", 6382))
+  val sentinels = List(("localhost", 26379), ("localhost", 26380), ("localhost", 26381), ("localhost", 26382))
+  val hostClients = hosts map Function.tupled(new RedisClient(_, _))
+  val sentinelClients = sentinels map Function.tupled(new SentinelClient(_, _))
+
+  override def beforeAll() {
+    hostClients.foreach { client =>
+      if (client.port != 6379) {
+        client.slaveof("localhost", 6379)
+      }
+    }
+
+    Thread sleep 10000 // wait for all the syncs to complete
+  }
+
+  override def afterAll() {
+    hostClients.foreach (_.slaveof())
+
+    Thread sleep 10000
+  }
+
+  describe("masters") {
+    it("should return all masters") {
+      sentinelClients.foreach { client =>
+        val masters = client.masters match {
+          case Some(m) => m.collect {
+            case Some(details) => (details("name"), details("ip"), details("port"))
+          }
+          case _ => Nil
+        }
+
+        masters should equal (List(("scala-redis-test", "127.0.0.1", "6379")))
+      }
+    }
+  }
+
+  describe("slaves") {
+    it("should return all slaves") {
+      sentinelClients.foreach { client =>
+        val slaves = (client.slaves("scala-redis-test") match {
+          case Some(s) => s.collect {
+            case Some(details) => (details("ip"), details("port").toInt)
+          }
+          case _ => Nil
+        }).sorted
+
+        slaves should equal (List(("127.0.0.1", 6380), ("127.0.0.1", 6381), ("127.0.0.1", 6382)))
+      }
+    }
+  }
+
+  describe("is-master-down-by-addr") {
+    it("should report master is not down") {
+      sentinelClients.foreach { client =>
+        client.isMasterDownByAddr("127.0.0.1", 6379).get._1 should equal (false)
+      }
+    }
+  }
+
+  describe("get-master-addr-by-name") {
+    it("should return master address") {
+      sentinelClients.foreach { client =>
+        client.getMasterAddrByName("scala-redis-test") should equal (Some(("127.0.0.1", 6379)))
+      }
+    }
+  }
+
+  describe("reset") {
+    it("should reset one master") {
+      sentinelClients.foreach { client =>
+        client.reset("scala-redis-*") should equal (Some(1))
+      }
+
+      Thread sleep 10000 // wait for sentinels to pick up slaves again
+    }
+  }
+
+  describe("failover") {
+    it("should automatically update master ip in client") {
+      val masterAddr = new SentinelMonitoredMasterAddress(sentinels, "scala-redis-test")
+      val master = new RedisClient(masterAddr)
+
+      val oldPort = master.port
+
+      sentinelClients(0).failover("scala-redis-test")
+      Thread sleep 30000
+
+      master.port should not equal oldPort
+
+      masterAddr.stopMonitoring()
+    }
+
+    it("should automatically update master ip in pool") {
+      val masterAddr = new SentinelMonitoredMasterAddress(sentinels, "scala-redis-test")
+      val pool = new RedisClientPool(masterAddr)
+
+      var oldPort = -1
+      pool.withClient { client =>
+        oldPort = client.port
+      }
+      oldPort should not equal -1
+
+      sentinelClients(0).failover("scala-redis-test")
+      Thread sleep 30000
+
+      pool.withClient { client =>
+        client.port should not equal oldPort
+      }
+
+      masterAddr.stopMonitoring()
+    }
+  }
+}


### PR DESCRIPTION
I added a sentinel client, plus dynamic master address support for the normal clients. There's a tiny breaking API change, due to the default parameters on `RedisClientPool` and the fact that scala apparently only supports default parameters on the primary constructor.

My bootstrap script to make testing easier:

``` bash
#!/usr/bin/env bash

set -e
trap 'kill $PID0 $PID1 $PID2 $PID3 $PID4 $PID5 $PID6 $PID7 > /dev/null 2>&1' EXIT

function start_node {
    redis-server --port $1 --save "" > /dev/null 2>&1 &
}

function start_sentinel {
    redis-server --sentinel --port $1 --sentinel monitor scala-redis-test localhost 6379 2 > /dev/null 2>&1 &
}

start_node 6379
PID0=$!
start_node 6380
PID1=$!
start_node 6381
PID2=$!
start_node 6382
PID3=$!
start_sentinel 26379
PID4=$!
start_sentinel 26380
PID5=$!
start_sentinel 26381
PID6=$!
start_sentinel 26382
PID7=$!

sbt test
```
