### PR TITLE
update scala 2.11.2 and akka 2.3.6

### DIFF
--- a/project/ScalaRedisProject.scala
+++ b/project/ScalaRedisProject.scala
@@ -9,11 +9,11 @@ object ScalaRedisProject extends Build
   lazy val commonSettings: Seq[Setting[_]] = Seq(
     organization := "net.debasishg",
     version := "2.13",
-    scalaVersion := "2.11.1",
-    crossScalaVersions := Seq("2.11.1", "2.10.4"),
+    scalaVersion := "2.11.2",
+    crossScalaVersions := Seq("2.11.2", "2.10.4"),
 
     scalacOptions in Compile ++= Seq( "-unchecked", "-feature", "-language:postfixOps", "-deprecation" ),
-    
+
     resolvers ++= Seq(akkaRepo)
   )
 
@@ -24,7 +24,7 @@ object ScalaRedisProject extends Build
       "org.slf4j"         %  "slf4j-api"               % "1.7.2",
       "org.slf4j"         %  "slf4j-log4j12"           % "1.7.2"      % "provided",
       "log4j"             %  "log4j"                   % "1.2.16"     % "provided",
-      "com.typesafe.akka" %% "akka-actor"              % "2.3.2",
+      "com.typesafe.akka" %% "akka-actor"              % "2.3.6",
       "junit"             %  "junit"                   % "4.8.1"      % "test",
       "org.scalatest"     %%  "scalatest"              % "2.1.3" % "test"),
 


### PR DESCRIPTION
- Scala 2.11.1 has several issues in the collections library.
- Akka 2.3.5 was released for Scala 2.10.4 and 2.11.2
