### PR TITLE
Added SCAN, SSCAN, HSCAN, ZSCAN functionality.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.5

--- a/src/main/scala/com/redis/HashOperations.scala
+++ b/src/main/scala/com/redis/HashOperations.scala
@@ -45,4 +45,9 @@ trait HashOperations { self: Redis =>
   
   def hgetall[K,V](key: Any)(implicit format: Format, parseK: Parse[K], parseV: Parse[V]): Option[Map[K,V]] =
     send("HGETALL", List(key))(asListPairs[K,V].map(_.flatten.toMap))
+
+  // HSCAN
+  // Incrementally iterate hash fields and associated values (since 2.8)
+  def hscan[A](key: Any, cursor: Int, pattern: Any = "*", count: Int = 10)(implicit format: Format, parse: Parse[A]): Option[(Option[Int], Option[List[Option[A]]])] =
+    send("HSCAN", key :: cursor :: ((x: List[Any]) => if(pattern == "*") x else "match" :: pattern :: x)(if(count == 10) Nil else List("count", count)))(asPair)
 }

--- a/src/main/scala/com/redis/Operations.scala
+++ b/src/main/scala/com/redis/Operations.scala
@@ -161,4 +161,9 @@ trait Operations { self: Redis =>
   // to persistent (a key that will never expire as no timeout is associated).
   def persist(key: Any)(implicit format: Format): Boolean =
     send("PERSIST", List(key))(asBoolean)
+
+  // SCAN
+  // Incrementally iterate the keys space (since 2.8)
+  def scan[A](cursor: Int, pattern: Any = "*", count: Int = 10)(implicit format: Format, parse: Parse[A]): Option[(Option[Int], Option[List[Option[A]]])] =
+    send("SCAN", cursor :: ((x: List[Any]) => if(pattern == "*") x else "match" :: pattern :: x)(if(count == 10) Nil else List("count", count)))(asPair)
 }

--- a/src/main/scala/com/redis/SetOperations.scala
+++ b/src/main/scala/com/redis/SetOperations.scala
@@ -85,4 +85,9 @@ trait SetOperations { self: Redis =>
   // Return multiple random elements from a Set (since 2.6)
   def srandmember[A](key: Any, count: Int)(implicit format: Format, parse: Parse[A]): Option[List[Option[A]]] =
     send("SRANDMEMBER", List(key, count))(asList)
+
+  // SSCAN
+  // Incrementally iterate Set elements (since 2.8)
+  def sscan[A](key: Any, cursor: Int, pattern: Any = "*", count: Int = 10)(implicit format: Format, parse: Parse[A]): Option[(Option[Int], Option[List[Option[A]]])] =
+    send("SSCAN", key :: cursor :: ((x: List[Any]) => if(pattern == "*") x else "match" :: pattern :: x)(if(count == 10) Nil else List("count", count)))(asPair)
 }

--- a/src/main/scala/com/redis/SortedSetOperations.scala
+++ b/src/main/scala/com/redis/SortedSetOperations.scala
@@ -135,4 +135,9 @@ trait SortedSetOperations { self: Redis =>
   def zcount(key: Any, min: Double = Double.NegativeInfinity, max: Double = Double.PositiveInfinity, minInclusive: Boolean = true, maxInclusive: Boolean = true)(implicit format: Format): Option[Long] =
     send("ZCOUNT", List(key, Format.formatDouble(min, minInclusive), Format.formatDouble(max, maxInclusive)))(asLong)
 
+  // ZSCAN
+  // Incrementally iterate sorted sets elements and associated scores (since 2.8)
+  def zscan[A](key: Any, cursor: Int, pattern: Any = "*", count: Int = 10)(implicit format: Format, parse: Parse[A]): Option[(Option[Int], Option[List[Option[A]]])] =
+    send("ZSCAN", key :: cursor :: ((x: List[Any]) => if(pattern == "*") x else "match" :: pattern :: x)(if(count == 10) Nil else List("count", count)))(asPair)
+
 }


### PR DESCRIPTION
You can change the sbt version in build.properties to correspond to your Java and sbt version. This is funcitonal with Java 1.8. Forked from debasishg/scala-redis repository.
