### PR TITLE
Keep `select`ed database when reconnect

### DIFF
--- a/src/main/scala/com/redis/RedisClient.scala
+++ b/src/main/scala/com/redis/RedisClient.scala
@@ -47,10 +47,10 @@ trait Redis extends IO with Protocol {
     in.iterator.flatMap(x => Iterator(x._1, x._2)).toList
 
   def reconnect: Boolean = {
-    disconnect && initialize
+    disconnect && initialize(db)
   }
   
-  protected def initialize : Boolean
+  protected def initialize(db: Int) : Boolean
 }
 
 trait RedisCommand extends Redis with Operations
@@ -67,9 +67,9 @@ trait RedisCommand extends Redis with Operations
   val database: Int = 0
   val secret: Option[Any] = None
   
-  override def initialize : Boolean = {
+  override def initialize(db: Int) : Boolean = {
     if(connect) {
-      selectDatabase
+      selectDatabase(db)
       secret.foreach {s => 
         auth(s)
       }
@@ -79,9 +79,9 @@ trait RedisCommand extends Redis with Operations
     }
   }
   
-  private def selectDatabase {
-    if (database != 0)
-      select(database)
+  private def selectDatabase(db: Int) {
+    if (db != 0)
+      select(db)
   }
 
   private def authenticate {
@@ -95,7 +95,7 @@ class RedisClient(override val host: String, override val port: Int,
     override val database: Int = 0, override val secret: Option[Any] = None, override val timeout : Int = 0)
   extends RedisCommand with PubSub {
 
-  initialize
+  initialize(database)
 
   def this() = this("localhost", 6379)
   override def toString = host + ":" + String.valueOf(port)
@@ -202,6 +202,6 @@ class RedisClient(override val host: String, override val port: Int,
     override def write(data: Array[Byte]) = parent.write(data)
     override def readLine = parent.readLine
     override def readCounted(count: Int) = parent.readCounted(count)
-    override def initialize = parent.initialize
+    override def initialize(db: Int) = parent.initialize(db)
   }
 }

--- a/src/main/scala/com/redis/ds/Deque.scala
+++ b/src/main/scala/com/redis/ds/Deque.scala
@@ -84,6 +84,6 @@ class RedisDequeClient(val h: String, val p: Int, val d: Int = 0, val s: Option[
       val key = k
       override val database = d
       override val secret = s
-      initialize
+      initialize(database)
     }
 }

--- a/src/test/scala/com/redis/OperationsSpec.scala
+++ b/src/test/scala/com/redis/OperationsSpec.scala
@@ -189,4 +189,15 @@ class OperationsSpec extends FunSpec
       r.setConfig("loglevel", "debug").get should equal("OK")
     }
   }
+
+  describe("select") {
+    it("should keep selected database when reconnect") {
+      val key = new scala.util.Random().nextString(10)
+      r.select(1)
+      r.set(key, "debasish")
+      r.get(key) should equal(Some("debasish"))
+      r.reconnect
+      r.get(key) should equal(Some("debasish"))
+    }
+  }
 }


### PR DESCRIPTION
Library users cannot detect lost of connection and reconnection, but reconnection resets the current database. (ref. #77)
