### PR TITLE
Moved database select to after auth

### DIFF
--- a/src/main/scala/com/redis/RedisClient.scala
+++ b/src/main/scala/com/redis/RedisClient.scala
@@ -69,10 +69,10 @@ trait RedisCommand extends Redis with Operations
   
   override def initialize : Boolean = {
     if(connect) {
-      selectDatabase
       secret.foreach {s => 
         auth(s)
       }
+      selectDatabase
       true
     } else {
       false


### PR DESCRIPTION
If you try to select database before you've authed, you get a NOAUTH exception