### PR TITLE
Support for unix domain sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Let us connect and get a key:
     scala> import com.redis._
     import com.redis._
 
-    scala> val r = new RedisClient("localhost", 6379)
+    scala> val r = new RedisClient("localhost", Some(6379))
     r: com.redis.RedisClient = localhost:6379
 
     scala> r.set("key", "some value")
@@ -114,7 +114,7 @@ scala-redis is a blocking client, which serves the purpose in most of the cases 
 scala-redis includes a Pool implementation which can be used to serve this purpose. Based on Apache Commons Pool implementation, RedisClientPool maintains a pool of instances of RedisClient, which can grow based on demand. Here's a sample usage ..
 
 ```scala
-val clients = new RedisClientPool("localhost", 6379)
+val clients = new RedisClientPool("localhost", Some(6379))
 def lp(msgs: List[String]) = {
   clients.withClient {
     client => {

--- a/project/ScalaRedisProject.scala
+++ b/project/ScalaRedisProject.scala
@@ -25,6 +25,7 @@ object ScalaRedisProject extends Build
       "org.slf4j"         %  "slf4j-log4j12"           % "1.7.2"      % "provided",
       "log4j"             %  "log4j"                   % "1.2.16"     % "provided",
       "com.typesafe.akka" %% "akka-actor"              % "2.3.6",
+      "com.kohlschutter.junixsocket" % "junixsocket-native-common" % "2.0.4",
       "junit"             %  "junit"                   % "4.8.1"      % "test",
       "org.scalatest"     %%  "scalatest"              % "2.1.3" % "test"),
 

--- a/src/main/scala/com/redis/RedisClient.scala
+++ b/src/main/scala/com/redis/RedisClient.scala
@@ -91,14 +91,19 @@ trait RedisCommand extends Redis with Operations
 }
   
 
-class RedisClient(override val host: String, override val port: Int,
+class RedisClient(override val host: String, override val port: Option[Int],
     override val database: Int = 0, override val secret: Option[Any] = None, override val timeout : Int = 0)
   extends RedisCommand with PubSub {
 
   initialize
 
-  def this() = this("localhost", 6379)
-  override def toString = host + ":" + String.valueOf(port)
+  def this() = this("localhost", Some(6379))
+  override def toString = {
+    port match {
+      case Some(portValue: Int) => host + ":" + String.valueOf(portValue)
+      case None => "unix://" ++ host
+    } 
+  }
 
   def pipeline(f: PipelineClient => Any): Option[List[Any]] = {
     send("MULTI")(asString) // flush reply stream

--- a/src/main/scala/com/redis/cluster/RedisCluster.scala
+++ b/src/main/scala/com/redis/cluster/RedisCluster.scala
@@ -53,7 +53,7 @@ object NoOpKeyTag extends KeyTag {
  * a level of abstraction for each node decoupling it from the address. A node is now identified
  * by a name, so functions like <tt>replaceServer</tt> works seamlessly.
  */
-case class ClusterNode(nodename: String, host: String, port: Int, database: Int = 0, maxIdle: Int = 8, secret: Option[Any] = None, timeout : Int = 0){
+case class ClusterNode(nodename: String, host: String, port: Option[Int], database: Int = 0, maxIdle: Int = 8, secret: Option[Any] = None, timeout : Int = 0){
   override def toString = nodename
 }
 
@@ -61,7 +61,7 @@ abstract class RedisCluster(hosts: ClusterNode*) extends RedisCommand {
 
   // not needed at cluster level
   override val host = null
-  override val port = 0
+  override val port = Some(0)
   override val timeout = 0
 
   // abstract val

--- a/src/main/scala/com/redis/cluster/RedisShards.scala
+++ b/src/main/scala/com/redis/cluster/RedisShards.scala
@@ -7,7 +7,7 @@ abstract class RedisShards(val hosts: List[ClusterNode]) extends RedisCommand {
 
   // not needed at cluster level
   override val host = null
-  override val port = 0
+  override val port = Some(0)
   override val timeout = 0
 
   // abstract val

--- a/src/main/scala/com/redis/ds/Deque.scala
+++ b/src/main/scala/com/redis/ds/Deque.scala
@@ -75,7 +75,7 @@ abstract class RedisDeque[A](val blocking: Boolean = false, val timeoutInSecs: I
 
 import com.redis.RedisCommand
 
-class RedisDequeClient(val h: String, val p: Int, val d: Int = 0, val s: Option[Any] = None, val t : Int =0) {
+class RedisDequeClient(val h: String, val p: Option[Int], val d: Int = 0, val s: Option[Any] = None, val t : Int =0) {
   def getDeque[A](k: String, blocking: Boolean = false, timeoutInSecs: Int = 0)(implicit format: Format, parse: Parse[A]) =
     new RedisDeque(blocking, timeoutInSecs)(format, parse) with RedisCommand {
       val host = h

--- a/src/test/scala/com/redis/BlockingDequeSpec.scala
+++ b/src/test/scala/com/redis/BlockingDequeSpec.scala
@@ -17,8 +17,8 @@ class BlockingDequeSpec extends FunSpec
   describe("blocking poll") {
     it("should pull out first element") {
 
-      val r1 = new RedisDequeClient("localhost", 6379).getDeque("btd", blocking = true, timeoutInSecs = 30)
-      val r2 = new RedisDequeClient("localhost", 6379).getDeque("btd", blocking = true, timeoutInSecs = 30)
+      val r1 = new RedisDequeClient("localhost", Some(6379)).getDeque("btd", blocking = true, timeoutInSecs = 30)
+      val r2 = new RedisDequeClient("localhost", Some(6379)).getDeque("btd", blocking = true, timeoutInSecs = 30)
 
       class Foo extends Runnable {
         def start () {
@@ -43,8 +43,8 @@ class BlockingDequeSpec extends FunSpec
   describe("blocking poll with pollLast") {
     it("should pull out first element") {
 
-      val r1 = new RedisDequeClient("localhost", 6379).getDeque("btd", blocking = true, timeoutInSecs = 30)
-      val r2 = new RedisDequeClient("localhost", 6379).getDeque("btd", blocking = true, timeoutInSecs = 30)
+      val r1 = new RedisDequeClient("localhost", Some(6379)).getDeque("btd", blocking = true, timeoutInSecs = 30)
+      val r2 = new RedisDequeClient("localhost", Some(6379)).getDeque("btd", blocking = true, timeoutInSecs = 30)
 
       class Foo extends Runnable {
         def start () {

--- a/src/test/scala/com/redis/DequeSpec.scala
+++ b/src/test/scala/com/redis/DequeSpec.scala
@@ -14,7 +14,7 @@ class DequeSpec extends FunSpec
                 with BeforeAndAfterEach
                 with BeforeAndAfterAll {
 
-  val r = new RedisDequeClient("localhost", 6379).getDeque("td")
+  val r = new RedisDequeClient("localhost", Some(6379)).getDeque("td")
 
   override def beforeEach = {
     r.clear

--- a/src/test/scala/com/redis/EvalOperationsSpec.scala
+++ b/src/test/scala/com/redis/EvalOperationsSpec.scala
@@ -14,7 +14,7 @@ class EvalOperationsSpec extends FunSpec
                      with BeforeAndAfterEach
                      with BeforeAndAfterAll {
 
-  val r = new RedisClient("localhost", 6379)
+  val r = new RedisClient("localhost", Some(6379))
 
   override def beforeEach = {
   }

--- a/src/test/scala/com/redis/HashOperationsSpec.scala
+++ b/src/test/scala/com/redis/HashOperationsSpec.scala
@@ -14,7 +14,7 @@ class HashOperationsSpec extends FunSpec
                      with BeforeAndAfterEach
                      with BeforeAndAfterAll {
 
-  val r = new RedisClient("localhost", 6379)
+  val r = new RedisClient("localhost", Some(6379))
 
   override def beforeEach = {
   }

--- a/src/test/scala/com/redis/HyperLogLogOperationsSpec.scala
+++ b/src/test/scala/com/redis/HyperLogLogOperationsSpec.scala
@@ -11,7 +11,7 @@ class HyperLogLogOperationsSpec extends FunSpec
                          with BeforeAndAfterEach
                          with BeforeAndAfterAll {
 
-  val r = new RedisClient("localhost", 6379)
+  val r = new RedisClient("localhost", Some(6379))
 
   override def beforeEach = {
   }

--- a/src/test/scala/com/redis/ListOperationsSpec.scala
+++ b/src/test/scala/com/redis/ListOperationsSpec.scala
@@ -14,7 +14,7 @@ class ListOperationsSpec extends FunSpec
                          with BeforeAndAfterEach
                          with BeforeAndAfterAll {
 
-  val r = new RedisClient("localhost", 6379)
+  val r = new RedisClient("localhost", Some(6379))
 
   override def beforeEach = {
   }
@@ -352,7 +352,7 @@ class ListOperationsSpec extends FunSpec
     }
 
     it("should pop blockingly") {
-      val r1 = new RedisClient("localhost", 6379)
+      val r1 = new RedisClient("localhost", Some(6379))
       class Foo extends Runnable {
         def start () {
           val myThread = new Thread(this) ;
@@ -381,7 +381,7 @@ class ListOperationsSpec extends FunSpec
 
   describe("blpop") {
     it ("should pop in a blocking mode") {
-      val r1 = new RedisClient("localhost", 6379)
+      val r1 = new RedisClient("localhost", Some(6379))
       class Foo extends Runnable {
         def start () {
           val myThread = new Thread(this) ;

--- a/src/test/scala/com/redis/OperationsSpec.scala
+++ b/src/test/scala/com/redis/OperationsSpec.scala
@@ -14,7 +14,7 @@ class OperationsSpec extends FunSpec
                      with BeforeAndAfterEach
                      with BeforeAndAfterAll {
 
-  val r = new RedisClient("localhost", 6379)
+  val r = new RedisClient("localhost", Some(6379))
 
   override def beforeEach = {
   }

--- a/src/test/scala/com/redis/PatternsSpec.scala
+++ b/src/test/scala/com/redis/PatternsSpec.scala
@@ -15,7 +15,7 @@ class PatternsSpec extends FunSpec
                with BeforeAndAfterEach
                with BeforeAndAfterAll {
 
-  implicit val clients = new RedisClientPool("localhost", 6379)
+  implicit val clients = new RedisClientPool("localhost", Some(6379))
 
   override def beforeEach = {
   }

--- a/src/test/scala/com/redis/PipelineSpec.scala
+++ b/src/test/scala/com/redis/PipelineSpec.scala
@@ -12,7 +12,7 @@ class PipelineSpec extends FunSpec
                    with BeforeAndAfterAll
                    with Inside {
 
-  val r = new RedisClient("localhost", 6379)
+  val r = new RedisClient("localhost", Some(6379))
 
   override def beforeEach = {
   }

--- a/src/test/scala/com/redis/PoolSpec.scala
+++ b/src/test/scala/com/redis/PoolSpec.scala
@@ -17,7 +17,7 @@ class PoolSpec extends FunSpec
                with BeforeAndAfterEach
                with BeforeAndAfterAll {
 
-  implicit val clients = new RedisClientPool("localhost", 6379)
+  implicit val clients = new RedisClientPool("localhost", Some(6379))
 
   override def beforeEach = {
   }

--- a/src/test/scala/com/redis/PubSubServerDemo.scala
+++ b/src/test/scala/com/redis/PubSubServerDemo.scala
@@ -10,7 +10,7 @@ case object GoDown
 class Pub extends Actor {
   println("starting publishing service ..")
   val system = ActorSystem("pub")
-  val r = new RedisClient("localhost", 6379)
+  val r = new RedisClient("localhost", Some(6379))
   val p = system.actorOf(Props(new Publisher(r)))
 
   def receive = {
@@ -32,7 +32,7 @@ class Pub extends Actor {
 class Sub extends Actor {
   println("starting subscription service ..")
   val system = ActorSystem("sub")
-  val r = new RedisClient("localhost", 6379)
+  val r = new RedisClient("localhost", Some(6379))
   val s = system.actorOf(Props(new Subscriber(r)))
   s ! Register(callback) 
 

--- a/src/test/scala/com/redis/PubSubSpec.scala
+++ b/src/test/scala/com/redis/PubSubSpec.scala
@@ -14,8 +14,8 @@ class PubSubSpec extends FunSpec
                  with BeforeAndAfterEach
                  with BeforeAndAfterAll {
 
-  val r = new RedisClient("localhost", 6379)
-  val t = new RedisClient("localhost", 6379)
+  val r = new RedisClient("localhost", Some(6379))
+  val t = new RedisClient("localhost", Some(6379))
 
   override def afterAll = {
     // r.disconnect

--- a/src/test/scala/com/redis/SerializationSpec.scala
+++ b/src/test/scala/com/redis/SerializationSpec.scala
@@ -15,7 +15,7 @@ class SerializationSpec extends FunSpec
                      with BeforeAndAfterEach
                      with BeforeAndAfterAll {
 
-  val r = new RedisClient("localhost", 6379)
+  val r = new RedisClient("localhost", Some(6379))
 
   override def beforeEach = {
   }

--- a/src/test/scala/com/redis/SetOperationsSpec.scala
+++ b/src/test/scala/com/redis/SetOperationsSpec.scala
@@ -14,7 +14,7 @@ class SetOperationsSpec extends FunSpec
                         with BeforeAndAfterEach
                         with BeforeAndAfterAll {
 
-  val r = new RedisClient("localhost", 6379)
+  val r = new RedisClient("localhost", Some(6379))
 
   override def beforeEach = {
   }

--- a/src/test/scala/com/redis/SortedSetOperationsSpec.scala
+++ b/src/test/scala/com/redis/SortedSetOperationsSpec.scala
@@ -15,7 +15,7 @@ class SortedSetOperationsSpec extends FunSpec
                         with BeforeAndAfterEach
                         with BeforeAndAfterAll {
 
-  val r = new RedisClient("localhost", 6379)
+  val r = new RedisClient("localhost", Some(6379))
 
   override def beforeEach = {
   }

--- a/src/test/scala/com/redis/StringOperationsSpec.scala
+++ b/src/test/scala/com/redis/StringOperationsSpec.scala
@@ -14,7 +14,7 @@ with Matchers
 with BeforeAndAfterEach
 with BeforeAndAfterAll {
 
-  val r = new RedisClient("localhost", 6379)
+  val r = new RedisClient("localhost", Some(6379))
 
   override def beforeEach = {
   }

--- a/src/test/scala/com/redis/UnixSocketSpec.scala
+++ b/src/test/scala/com/redis/UnixSocketSpec.scala
@@ -16,7 +16,7 @@ class UnixSocketSpec extends FunSpec
                          with BeforeAndAfterEach
                          with BeforeAndAfterAll {
 
-  val r = new RedisClient("/tmp/redis.sock", -1)
+  val r = new RedisClient("/tmp/redis.sock", None)
 
   override def beforeEach = {
   }

--- a/src/test/scala/com/redis/UnixSocketSpec.scala
+++ b/src/test/scala/com/redis/UnixSocketSpec.scala
@@ -1,0 +1,80 @@
+package com.redis
+
+import org.scalatest.FunSpec
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+import org.junit.runner.RunWith
+
+// for this Spec to pass enable unix sockets support in redis by setting `unixsocket` in
+// redis.conf to /tmp/redis.sock
+
+@RunWith(classOf[JUnitRunner])
+class UnixSocketSpec extends FunSpec 
+                         with Matchers
+                         with BeforeAndAfterEach
+                         with BeforeAndAfterAll {
+
+  val r = new RedisClient("/tmp/redis.sock", -1)
+
+  override def beforeEach = {
+  }
+
+  override def afterEach = {
+    r.flushdb
+  }
+
+  override def afterAll = {
+    r.disconnect
+  }
+
+  describe("lpush") {
+    it("should add to the head of the list") {
+      r.lpush("list-1", "foo") should equal(Some(1))
+      r.lpush("list-1", "bar") should equal(Some(2))
+    }
+    it("should throw if the key has a non-list value") {
+      r.set("anshin-1", "debasish") should equal(true)
+      val thrown = the [Exception] thrownBy { r.lpush("anshin-1", "bar") }
+      thrown.getMessage should include("Operation against a key holding the wrong kind of value")
+    }
+  }
+
+  describe("sadd") {
+    it("should add a non-existent value to the set") {
+      r.sadd("set-1", "foo").get should equal(1)
+      r.sadd("set-1", "bar").get should equal(1)
+    }
+    it("should not add an existing value to the set") {
+      r.sadd("set-1", "foo").get should equal(1)
+      r.sadd("set-1", "foo").get should equal(0)
+    }
+    it("should fail if the key points to a non-set") {
+      r.lpush("list-1", "foo") should equal(Some(1))
+      val thrown = the [Exception] thrownBy { r.sadd("list-1", "foo") }
+      thrown.getMessage should include ("Operation against a key holding the wrong kind of value")
+    }
+  }
+
+  describe("set if not exist") {
+    it("should set key/value pairs with exclusiveness and expire") {
+      r.set("amit-1", "mor", "nx","ex",6)
+      r.get("amit-1") match {
+        case Some(s: String) => s should equal("mor")
+        case None => fail("should return mor")
+      }
+      r.del("amit-1")
+    }
+  }
+
+  describe("pipeline1") {
+    it("should do pipelined commands") {
+      r.pipeline { p =>
+        p.set("key", "debasish")
+        p.get("key")
+        p.get("key1")
+      }.get should equal(List(true, Some("debasish"), None))
+    }
+  }
+}

--- a/src/test/scala/com/redis/WatchSpec.scala
+++ b/src/test/scala/com/redis/WatchSpec.scala
@@ -14,7 +14,7 @@ class WatchSpec extends FunSpec
                      with BeforeAndAfterEach
                      with BeforeAndAfterAll {
 
-  implicit val clients = new RedisClientPool("localhost", 6379)
+  implicit val clients = new RedisClientPool("localhost", Some(6379))
 
   override def beforeEach = {
   }
@@ -30,7 +30,7 @@ class WatchSpec extends FunSpec
 
   describe("watch") {
     it("should fail a transaction if modified from another client") {
-      implicit val clients = new RedisClientPool("localhost", 6379)
+      implicit val clients = new RedisClientPool("localhost", Some(6379))
       class P1 extends Runnable {
         def run() {
           clients.withClient { client =>

--- a/src/test/scala/com/redis/cluster/RedisClusterSpec.scala
+++ b/src/test/scala/com/redis/cluster/RedisClusterSpec.scala
@@ -17,7 +17,7 @@ class RedisClusterSpec extends FunSpec
                        with BeforeAndAfterEach
                        with BeforeAndAfterAll {
 
-  val nodes = Array(ClusterNode("node1", "localhost", 6379), ClusterNode("node2", "localhost", 6380), ClusterNode("node3", "localhost", 6381))
+  val nodes = Array(ClusterNode("node1", "localhost", Some(6379)), ClusterNode("node2", "localhost", Some(6380)), ClusterNode("node3", "localhost", Some(6381)))
   val r = new RedisCluster(new WrappedArray.ofRef(nodes): _*) {
     val keyTag = Some(RegexKeyTag)
   }
@@ -114,13 +114,13 @@ class RedisClusterSpec extends FunSpec
 
       //simulate the same value is duplicated to slave
       //for test, don't set to master, just to make sure the expected value is loaded from slave
-      val redisClient = new RedisClient("localhost", 6382)
+      val redisClient = new RedisClient("localhost", Some(6382))
       redisClient.set("testkey1", "testvalue1")
 
       //replaced master with slave on the same node
-      r.replaceServer(ClusterNode(nodename, "localhost", 6382))
-      r.nodeForKey("testkey1").port should equal (6382)
-      r.hr.cluster.find(_.node.nodename.equals(nodename)).get.port should equal(6382)
+      r.replaceServer(ClusterNode(nodename, "localhost", Some(6382)))
+      r.nodeForKey("testkey1").port should equal (Some(6382))
+      r.hr.cluster.find(_.node.nodename.equals(nodename)).get.port should equal(Some(6382))
       r.get("testkey1") should equal (Some("testvalue1"))
 
       //switch back to master. the old value is loaded

--- a/src/test/scala/com/redis/cluster/RedisShardsSpec.scala
+++ b/src/test/scala/com/redis/cluster/RedisShardsSpec.scala
@@ -17,7 +17,7 @@ class RedisShardsSpec extends FunSpec
                        with BeforeAndAfterEach
                        with BeforeAndAfterAll {
 
-  val nodes = List(ClusterNode("node1", "localhost", 6379), ClusterNode("node2", "localhost", 6380), ClusterNode("node3", "localhost", 6381))
+  val nodes = List(ClusterNode("node1", "localhost", Some(6379)), ClusterNode("node2", "localhost", Some(6380)), ClusterNode("node3", "localhost", Some(6381)))
   val r = new RedisShards(nodes) {
     val keyTag = Some(RegexKeyTag)
   }
@@ -114,11 +114,11 @@ class RedisShardsSpec extends FunSpec
 
       //simulate the same value is duplicated to slave
       //for test, don't set to master, just to make sure the expected value is loaded from slave
-      val redisClient = new RedisClient("localhost", 6382)
+      val redisClient = new RedisClient("localhost", Some(6382))
       redisClient.set("testkey1", "testvalue1")
 
       //replaced master with slave on the same node
-      r.replaceServer(ClusterNode(nodename, "localhost", 6382))
+      r.replaceServer(ClusterNode(nodename, "localhost", Some(6382)))
       r.get("testkey1") should equal (Some("testvalue1"))
 
       //switch back to master. the old value is loaded


### PR DESCRIPTION
Hi

At the moment there is no way to use scala-redis with unix domain sockets instead of TCP/IP sockets, which is a pity at least because [redis documentation](http://redis.io/topics/benchmarks) suggests that using unix domain sockets has some performance benefits:

> When the server and client benchmark programs run on the same box, both the TCP/IP loopback and unix domain sockets can be used. Depending on the platform, unix domain sockets can achieve around 50% more throughput than the TCP/IP loopback (on Linux for instance). The default behavior of redis-benchmark is to use the TCP/IP loopback.
> 
> The performance benefit of unix domain sockets compared to TCP/IP loopback tends to decrease when pipelining is heavily used (i.e. long pipelines).

I put together [a fork](https://github.com/htch/scala-redis) to see if it holds true for the project i am working on, and i wasn't dissatisfied. I really hope that this feature can be integrated into scala-redis.

However i am not happy with my implementation: the syntax for initialising a connection pool with unix domain sockets should be made more explicit than passing a magical value `-1` as a port number and file path as a hostname; also i am not really sure how best to setup tests for this feature: listening on a unix domain socket is disabled by default, moreover different redis distributions have different conventions for the `unixsocket` path.

What's your opinion?
