### PR TITLE
Changed pool implementation to allow limiting the amount of connections

### DIFF
--- a/src/main/scala/com/redis/Pool.scala
+++ b/src/main/scala/com/redis/Pool.scala
@@ -36,7 +36,7 @@ object RedisClientPool {
 
 class RedisClientPool(val host: String, val port: Int, val maxIdle: Int = 8, val database: Int = 0, val secret: Option[Any] = None, val timeout : Int = 0, 
     val maxConnections: Int = RedisClientPool.UNLIMITED_CONNECTIONS, val whenExhaustedBehavior: Byte = RedisClientPool.WHEN_EXHAUSTED_BLOCK, val poolWaitTimeout: Long = 3000) {
-  val pool = new GenericObjectPool(new RedisClientFactory(host, port, database, secret, timeout), maxConnections, whenExhaustedBehavior, poolWaitTimeout, maxIdle)
+  val pool = new GenericObjectPool(new RedisClientFactory(host, port, database, secret, timeout), maxConnections, whenExhaustedBehavior, poolWaitTimeout, maxIdle, false, true)
   override def toString = host + ":" + String.valueOf(port)
 
   def withClient[T](body: RedisClient => T) = {

--- a/src/main/scala/com/redis/Pool.scala
+++ b/src/main/scala/com/redis/Pool.scala
@@ -26,8 +26,17 @@ private [redis] class RedisClientFactory(val host: String, val port: Int, val da
   def activateObject(rc: RedisClient): Unit = {}
 }
 
-class RedisClientPool(val host: String, val port: Int, val maxIdle: Int = 8, val database: Int = 0, val secret: Option[Any] = None, val timeout : Int = 0) {
-  val pool = new StackObjectPool(new RedisClientFactory(host, port, database, secret, timeout), maxIdle)
+object RedisClientPool {
+  val UNLIMITED_CONNECTIONS = -1
+
+  val WHEN_EXHAUSTED_BLOCK = GenericObjectPool.WHEN_EXHAUSTED_BLOCK
+  val WHEN_EXHAUSTED_FAIL = GenericObjectPool.WHEN_EXHAUSTED_FAIL
+  val WHEN_EXHAUSTED_GROW = GenericObjectPool.WHEN_EXHAUSTED_GROW
+}
+
+class RedisClientPool(val host: String, val port: Int, val maxIdle: Int = 8, val database: Int = 0, val secret: Option[Any] = None, val timeout : Int = 0, 
+    val maxConnections: Int = RedisClientPool.UNLIMITED_CONNECTIONS, val whenExhaustedBehavior: Byte = RedisClientPool.WHEN_EXHAUSTED_BLOCK, val poolWaitTimeout: Long = 3000) {
+  val pool = new GenericObjectPool(new RedisClientFactory(host, port, database, secret, timeout), maxConnections, whenExhaustedBehavior, poolWaitTimeout, maxIdle)
   override def toString = host + ":" + String.valueOf(port)
 
   def withClient[T](body: RedisClient => T) = {


### PR DESCRIPTION
The `StackObjectPool` allows for unlimited amount of connections in the pool. We experienced with that connection timeouts (most probably because the amount of sockets in the system became huge). Limiting the amount of RedisClients using the `GenericObjectPool` does fix that. 

Also, usage of cloud Redis solutions sometimes have connection limitations, so in that case it is useful to be able to restrict the max amount of connections being allowed. It's anyway good to restrict resource usage as things are finite anyhow (and it's better to be in control of the limit then to let the system limit the resources as the latter might give unexpected exceptions).

The default limit is -1 (unlimited) for backwards compatibility reasons. If you feel that some limit is better, feel free to change. 

I've enabled testing on Return (calls validateObject() on the factory), but disabled testing on borrow (as the write method in IO also takes care of that). 