### PR TITLE
DECRBY, HINCRBY, and INCRBY should all accept Long values

### DIFF
--- a/src/main/scala/com/redis/HashOperations.scala
+++ b/src/main/scala/com/redis/HashOperations.scala
@@ -25,7 +25,7 @@ trait HashOperations { self: Redis =>
       }
     }
 
-  def hincrby(key: Any, field: Any, value: Int)(implicit format: Format): Option[Long] =
+  def hincrby(key: Any, field: Any, value: Long)(implicit format: Format): Option[Long] =
     send("HINCRBY", List(key, field, value))(asLong)
 
   def hincrbyfloat(key: Any, field: Any, value: Float)(implicit format: Format): Option[Float] =

--- a/src/main/scala/com/redis/StringOperations.scala
+++ b/src/main/scala/com/redis/StringOperations.scala
@@ -58,7 +58,7 @@ trait StringOperations { self: Redis =>
 
   // INCR (key, increment)
   // increments the specified key by increment
-  def incrby(key: Any, increment: Int)(implicit format: Format): Option[Long] =
+  def incrby(key: Any, increment: Long)(implicit format: Format): Option[Long] =
     send("INCRBY", List(key, increment))(asLong)
 
   def incrbyfloat(key: Any, increment: Float)(implicit format: Format): Option[Float] =
@@ -71,7 +71,7 @@ trait StringOperations { self: Redis =>
 
   // DECR (key, increment)
   // decrements the specified key by increment
-  def decrby(key: Any, increment: Int)(implicit format: Format): Option[Long] =
+  def decrby(key: Any, increment: Long)(implicit format: Format): Option[Long] =
     send("DECRBY", List(key, increment))(asLong)
 
   // MGET (key, key, key, ...)

--- a/src/main/scala/com/redis/cluster/RedisCluster.scala
+++ b/src/main/scala/com/redis/cluster/RedisCluster.scala
@@ -185,9 +185,9 @@ abstract class RedisCluster(hosts: ClusterNode*) extends RedisCommand {
   override def setnx(key: Any, value: Any)(implicit format: Format) = processForKey(key)(_.setnx(key, value))
   override def setex(key: Any, expiry: Long, value: Any)(implicit format: Format) = processForKey(key)(_.setex(key, expiry, value))
   override def incr(key: Any)(implicit format: Format) = processForKey(key)(_.incr(key))
-  override def incrby(key: Any, increment: Int)(implicit format: Format) = processForKey(key)(_.incrby(key, increment))
+  override def incrby(key: Any, increment: Long)(implicit format: Format) = processForKey(key)(_.incrby(key, increment))
   override def decr(key: Any)(implicit format: Format) = processForKey(key)(_.decr(key))
-  override def decrby(key: Any, increment: Int)(implicit format: Format) = processForKey(key)(_.decrby(key, increment))
+  override def decrby(key: Any, increment: Long)(implicit format: Format) = processForKey(key)(_.decrby(key, increment))
 
   override def mget[A](key: Any, keys: Any*)(implicit format: Format, parse: Parse[A]): Option[List[Option[A]]] = {
     val keylist = (key :: keys.toList)

--- a/src/main/scala/com/redis/cluster/RedisShards.scala
+++ b/src/main/scala/com/redis/cluster/RedisShards.scala
@@ -122,9 +122,9 @@ abstract class RedisShards(val hosts: List[ClusterNode]) extends RedisCommand {
   override def setnx(key: Any, value: Any)(implicit format: Format) = processForKey(key)(_.setnx(key, value))
   override def setex(key: Any, expiry: Long, value: Any)(implicit format: Format) = processForKey(key)(_.setex(key, expiry, value))
   override def incr(key: Any)(implicit format: Format) = processForKey(key)(_.incr(key))
-  override def incrby(key: Any, increment: Int)(implicit format: Format) = processForKey(key)(_.incrby(key, increment))
+  override def incrby(key: Any, increment: Long)(implicit format: Format) = processForKey(key)(_.incrby(key, increment))
   override def decr(key: Any)(implicit format: Format) = processForKey(key)(_.decr(key))
-  override def decrby(key: Any, increment: Int)(implicit format: Format) = processForKey(key)(_.decrby(key, increment))
+  override def decrby(key: Any, increment: Long)(implicit format: Format) = processForKey(key)(_.decrby(key, increment))
 
   override def mget[A](key: Any, keys: Any*)(implicit format: Format, parse: Parse[A]): Option[List[Option[A]]] = {
     val keylist = (key :: keys.toList)


### PR DESCRIPTION
The documentation for all three of these commands states:

  "[The operation] is limited to 64 bit signed integers."
- http://redis.io/commands/hincrby
- http://redis.io/commands/decrby
- http://redis.io/commands/incrby
