### PR TITLE
Changed semantics of hgetall - now returns None instead of empty Map …

### DIFF
--- a/src/main/scala/com/redis/HashOperations.scala
+++ b/src/main/scala/com/redis/HashOperations.scala
@@ -46,14 +46,13 @@ trait HashOperations { self: Redis =>
   def hvals[A](key: Any)(implicit format: Format, parse: Parse[A]): Option[List[A]] =
     send("HVALS", List(key))(asList.map(_.flatten))
 
-  @deprecated("Use the more idiomatic variant hgetall1", "3.2")
+  @deprecated("Use the more idiomatic variant hgetall1, which has the returned Map behavior more consistent. See issue https://github.com/debasishg/scala-redis/issues/122", "3.2")
   def hgetall[K,V](key: Any)(implicit format: Format, parseK: Parse[K], parseV: Parse[V]): Option[Map[K,V]] =
     send("HGETALL", List(key))(asListPairs[K,V].map(_.flatten.toMap))
 
   def hgetall1[K,V](key: Any)(implicit format: Format, parseK: Parse[K], parseV: Parse[V]): Option[Map[K,V]] =
     send("HGETALL", List(key))(asListPairs[K,V].map(_.flatten.toMap)) match {
-      case Some(m) if m.isEmpty => None
-      case Some(m) => Some(m)
+      case s@Some(m) if m.nonEmpty => s
       case _ => None
     }
 

--- a/src/main/scala/com/redis/HashOperations.scala
+++ b/src/main/scala/com/redis/HashOperations.scala
@@ -46,8 +46,16 @@ trait HashOperations { self: Redis =>
   def hvals[A](key: Any)(implicit format: Format, parse: Parse[A]): Option[List[A]] =
     send("HVALS", List(key))(asList.map(_.flatten))
 
+  @deprecated("Use the more idiomatic variant hgetall1", "3.2")
   def hgetall[K,V](key: Any)(implicit format: Format, parseK: Parse[K], parseV: Parse[V]): Option[Map[K,V]] =
     send("HGETALL", List(key))(asListPairs[K,V].map(_.flatten.toMap))
+
+  def hgetall1[K,V](key: Any)(implicit format: Format, parseK: Parse[K], parseV: Parse[V]): Option[Map[K,V]] =
+    send("HGETALL", List(key))(asListPairs[K,V].map(_.flatten.toMap)) match {
+      case Some(m) if m.isEmpty => None
+      case Some(m) => Some(m)
+      case _ => None
+    }
 
   // HSCAN
   // Incrementally iterate hash fields and associated values (since 2.8)

--- a/src/main/scala/com/redis/cluster/RedisCluster.scala
+++ b/src/main/scala/com/redis/cluster/RedisCluster.scala
@@ -351,4 +351,5 @@ abstract class RedisCluster(hosts: ClusterNode*) extends RedisCommand {
   override def hkeys[A](key: Any)(implicit format: Format, parse: Parse[A]) = processForKey(key)(_.hkeys[A](key))
   override def hvals[A](key: Any)(implicit format: Format, parse: Parse[A]) = processForKey(key)(_.hvals[A](key))
   override def hgetall[K,V](key: Any)(implicit format: Format, parseK: Parse[K], parseV: Parse[V]) = processForKey(key)(_.hgetall[K,V](key))
+  override def hgetall1[K,V](key: Any)(implicit format: Format, parseK: Parse[K], parseV: Parse[V]) = processForKey(key)(_.hgetall1[K,V](key))
 }

--- a/src/main/scala/com/redis/cluster/RedisShards.scala
+++ b/src/main/scala/com/redis/cluster/RedisShards.scala
@@ -288,4 +288,5 @@ abstract class RedisShards(val hosts: List[ClusterNode]) extends RedisCommand {
   override def hkeys[A](key: Any)(implicit format: Format, parse: Parse[A]) = processForKey(key)(_.hkeys[A](key))
   override def hvals[A](key: Any)(implicit format: Format, parse: Parse[A]) = processForKey(key)(_.hvals[A](key))
   override def hgetall[K,V](key: Any)(implicit format: Format, parseK: Parse[K], parseV: Parse[V]) = processForKey(key)(_.hgetall[K,V](key))
+  override def hgetall1[K,V](key: Any)(implicit format: Format, parseK: Parse[K], parseV: Parse[V]) = processForKey(key)(_.hgetall1[K,V](key))
 }

--- a/src/test/scala/com/redis/HashOperationsSpec.scala
+++ b/src/test/scala/com/redis/HashOperationsSpec.scala
@@ -69,7 +69,7 @@ class HashOperationsSpec extends FunSpec
       r.hmset("hash7", Map("field1" -> "val1", "field2" -> "val2"))
       r.hkeys("hash7") should be(Some(List("field1", "field2")))
       r.hvals("hash7") should be(Some(List("val1", "val2")))
-      r.hgetall("hash7") should be(Some(Map("field1" -> "val1", "field2" -> "val2")))
+      r.hgetall1("hash7") should be(Some(Map("field1" -> "val1", "field2" -> "val2")))
     }
 
     it("should increment map values by floats") {

--- a/src/test/scala/com/redis/HashOperationsSpec.scala
+++ b/src/test/scala/com/redis/HashOperationsSpec.scala
@@ -82,4 +82,16 @@ class HashOperationsSpec extends FunSpec
       thrown.getMessage should include("hash value is not a valid float")
     }
   }
+
+  describe("hgetall1") {
+    it("should behave symmetrically with hmset") {
+      r.hmset("hash1", Map("field1" -> "val1", "field2" -> "val2"))
+      val thrown = the [Exception] thrownBy { r.hmset("hash2", Map()) }
+      r.hget("hash1", "field1") should be(Some("val1"))
+      r.hgetall1("hash1") should be(Some(Map("field1" -> "val1", "field2" -> "val2")))
+      r.hget("hash1", "foo") should be(None)
+      r.hgetall1("hash12") should be(None)
+    }
+  }
+    
 }


### PR DESCRIPTION
…for a non-existing key. New API is named hgetall1 and hgetall is deprecated