### PR TITLE
Implement evalSHABulk to parse received as bulk

### DIFF
--- a/src/main/scala/com/redis/EvalOperations.scala
+++ b/src/main/scala/com/redis/EvalOperations.scala
@@ -17,6 +17,9 @@ trait EvalOperations { self: Redis =>
     
   def evalSHA[A](shahash: String, keys: List[Any], args: List[Any])(implicit format: Format, parse: Parse[A]): Option[A] =
     send("EVALSHA", argsForEval(shahash, keys, args))(asAny.asInstanceOf[Option[A]])
+
+  def evalSHABulk[A](shahash: String, keys: List[Any], args: List[Any])(implicit format: Format, parse: Parse[A]): Option[A] =
+    send("EVALSHA", argsForEval(shahash, keys, args))(asBulk)
   
   def scriptLoad(luaCode: String): Option[String] = {
     send("SCRIPT", List("LOAD", luaCode))(asBulk)


### PR DESCRIPTION
It now parses result as **evalBulk** does. Actually, the only difference between **EVAL** and **EVALSHA** should be that EVAL receives a script and **EVALSHA** receives _SHA_ of the script, but it should behave the same and parse the received data the same way.

I wrote a new function **evalSHABulk** to avoid breaking anyone's code.