### PR TITLE
Added possibility to use java.net.Uri as param for RedisClient

### DIFF
--- a/src/main/scala/com/redis/RedisClient.scala
+++ b/src/main/scala/com/redis/RedisClient.scala
@@ -98,6 +98,15 @@ class RedisClient(override val host: String, override val port: Int,
   initialize
 
   def this() = this("localhost", 6379)
+  def this(connectionUri: java.net.URI) = this(
+    host = connectionUri.getHost,
+    port = connectionUri.getPort,
+    secret = Option(connectionUri.getUserInfo)
+      .flatMap(_.split(':') match {
+        case Array(_, password, _*) ⇒ Some(password)
+        case _ ⇒ None
+      })
+  )
   override def toString = host + ":" + String.valueOf(port)
 
   def pipeline(f: PipelineClient => Any): Option[List[Any]] = {


### PR DESCRIPTION
Some hosting platforms provide redis connection settings (host, port, password) as a single string (e.g., "redis://rediscloud:password@some.host.com:port"). It's convenient to have such RedisClient constructor overload because of it.