### PR TITLE
make HashOperations#hset return Option[Long]

### DIFF
--- a/src/main/scala/com/redis/HashOperations.scala
+++ b/src/main/scala/com/redis/HashOperations.scala
@@ -2,25 +2,68 @@ package com.redis
 
 import serialization._
 
-trait HashOperations { self: Redis =>
-  def hset(key: Any, field: Any, value: Any)(implicit format: Format): Option[Long] =
-    send("HSET", List(key, field, value))(asLong)
+trait HashOperations {
+  self: Redis =>
+  /**
+    * Sets <code>field</code> in the hash stored at <code>key</code> to <code>value</code>.
+    * If <code>key</code> does not exist, a new key holding a hash is created.
+    * If field already exists in the hash, it is overwritten.
+    *
+    * @see [[http://redis.io/commands/hset HSET documentation]]
+    * @deprecated return value semantics is inconsistent with [[com.redis.HashOperations#hsetnx]] and
+    *             [[com.redis.HashOperations#hmset]]. Use [[com.redis.HashOperations#hset1]] instead
+    * @return <code>True</code> if <code>field</code> is a new field in the hash and value was set,
+    *         <code>False</code> if <code>field</code> already exists in the hash and the value was updated.
+    *
+    */
+  def hset(key: Any, field: Any, value: Any)(implicit format: Format): Boolean =
+  send("HSET", List(key, field, value))(asBoolean)
 
+  /** Sets <code>field</code> in the hash stored at <code>key</code> to <code>value</code>.
+    * If <code>key</code> does not exist, a new key holding a hash is created.
+    * If field already exists in the hash, it is overwritten.
+    *
+    * @see [[http://redis.io/commands/hset HSET documentation]]
+    * @return <code>Some(0)</code> if <code>field</code> is a new field in the hash and value was set,
+    *         <code>Some(1)</code> if <code>field</code> already exists in the hash and the value was updated.
+    */
+  def hset1(key: Any, field: Any, value: Any)(implicit format: Format): Option[Long] =
+  send("HSET", List(key, field, value))(asLong)
+
+  /**
+    * Sets <code>field</code> in the hash stored at <code>key</code> to <code>value</code>, only if field does not yet exist.
+    * If key does not exist, a new key holding a hash is created.
+    * If field already exists, this operation has no effect.
+    *
+    * @see [[http://redis.io/commands/hsetnx HSETNX documentation]]
+    * @return <code>True</code> if <code>field</code> is a new field in the hash and value was set.
+    *         </code>False</code> if <code>field</code> exists in the hash and no operation was performed.
+    */
   def hsetnx(key: Any, field: Any, value: Any)(implicit format: Format): Boolean =
-    send("HSETNX", List(key, field, value))(asBoolean)
+  send("HSETNX", List(key, field, value))(asBoolean)
 
   def hget[A](key: Any, field: Any)(implicit format: Format, parse: Parse[A]): Option[A] =
     send("HGET", List(key, field))(asBulk)
 
-  def hmset(key: Any, map: Iterable[Product2[Any,Any]])(implicit format: Format): Boolean =
-    send("HMSET", key :: flattenPairs(map))(asBoolean)
+  /**
+    * Sets the specified fields to their respective values in the hash stored at key.
+    * This command overwrites any existing fields in the hash.
+    * If key does not exist, a new key holding a hash is created.
+    *
+    * @param map from fields to values
+    * @see [[http://redis.io/commands/hmset HMSET documentation]]
+    * @return <code>True</code> if operation completed successfully,
+    *         <code>False</code> otherwise.
+    */
+  def hmset(key: Any, map: Iterable[Product2[Any, Any]])(implicit format: Format): Boolean =
+  send("HMSET", key :: flattenPairs(map))(asBoolean)
 
-  def hmget[K,V](key: Any, fields: K*)(implicit format: Format, parseV: Parse[V]): Option[Map[K,V]] =
-    send("HMGET", key :: fields.toList){
+  def hmget[K, V](key: Any, fields: K*)(implicit format: Format, parseV: Parse[V]): Option[Map[K, V]] =
+    send("HMGET", key :: fields.toList) {
       asList.map { values =>
         fields.zip(values).flatMap {
-          case (field,Some(value)) => Some((field,value))
-          case (_,None) => None
+          case (field, Some(value)) => Some((field, value))
+          case (_, None) => None
         }.toMap
       }
     }
@@ -47,11 +90,11 @@ trait HashOperations { self: Redis =>
     send("HVALS", List(key))(asList.map(_.flatten))
 
   @deprecated("Use the more idiomatic variant hgetall1, which has the returned Map behavior more consistent. See issue https://github.com/debasishg/scala-redis/issues/122", "3.2")
-  def hgetall[K,V](key: Any)(implicit format: Format, parseK: Parse[K], parseV: Parse[V]): Option[Map[K,V]] =
-    send("HGETALL", List(key))(asListPairs[K,V].map(_.flatten.toMap))
+  def hgetall[K, V](key: Any)(implicit format: Format, parseK: Parse[K], parseV: Parse[V]): Option[Map[K, V]] =
+    send("HGETALL", List(key))(asListPairs[K, V].map(_.flatten.toMap))
 
-  def hgetall1[K,V](key: Any)(implicit format: Format, parseK: Parse[K], parseV: Parse[V]): Option[Map[K,V]] =
-    send("HGETALL", List(key))(asListPairs[K,V].map(_.flatten.toMap)) match {
+  def hgetall1[K, V](key: Any)(implicit format: Format, parseK: Parse[K], parseV: Parse[V]): Option[Map[K, V]] =
+    send("HGETALL", List(key))(asListPairs[K, V].map(_.flatten.toMap)) match {
       case s@Some(m) if m.nonEmpty => s
       case _ => None
     }
@@ -59,5 +102,5 @@ trait HashOperations { self: Redis =>
   // HSCAN
   // Incrementally iterate hash fields and associated values (since 2.8)
   def hscan[A](key: Any, cursor: Int, pattern: Any = "*", count: Int = 10)(implicit format: Format, parse: Parse[A]): Option[(Option[Int], Option[List[Option[A]]])] =
-    send("HSCAN", key :: cursor :: ((x: List[Any]) => if(pattern == "*") x else "match" :: pattern :: x)(if(count == 10) Nil else List("count", count)))(asPair)
+  send("HSCAN", key :: cursor :: ((x: List[Any]) => if (pattern == "*") x else "match" :: pattern :: x) (if (count == 10) Nil else List("count", count)))(asPair)
 }

--- a/src/main/scala/com/redis/HashOperations.scala
+++ b/src/main/scala/com/redis/HashOperations.scala
@@ -3,8 +3,8 @@ package com.redis
 import serialization._
 
 trait HashOperations { self: Redis =>
-  def hset(key: Any, field: Any, value: Any)(implicit format: Format): Boolean =
-    send("HSET", List(key, field, value))(asBoolean)
+  def hset(key: Any, field: Any, value: Any)(implicit format: Format): Option[Long] =
+    send("HSET", List(key, field, value))(asLong)
 
   def hsetnx(key: Any, field: Any, value: Any)(implicit format: Format): Boolean =
     send("HSETNX", List(key, field, value))(asBoolean)

--- a/src/main/scala/com/redis/cluster/RedisCluster.scala
+++ b/src/main/scala/com/redis/cluster/RedisCluster.scala
@@ -341,6 +341,7 @@ abstract class RedisCluster(hosts: ClusterNode*) extends RedisCommand {
    * HashOperations
    */
   override def hset(key: Any, field: Any, value: Any)(implicit format: Format) = processForKey(key)(_.hset(key, field, value))
+  override def hset1(key: Any, field: Any, value: Any)(implicit format: Format) = processForKey(key)(_.hset1(key, field, value))
   override def hget[A](key: Any, field: Any)(implicit format: Format, parse: Parse[A]) = processForKey(key)(_.hget[A](key, field))
   override def hmset(key: Any, map: Iterable[Product2[Any, Any]])(implicit format: Format) = processForKey(key)(_.hmset(key, map))
   override def hmget[K,V](key: Any, fields: K*)(implicit format: Format, parseV: Parse[V]) = processForKey(key)(_.hmget[K,V](key, fields:_*))

--- a/src/main/scala/com/redis/cluster/RedisShards.scala
+++ b/src/main/scala/com/redis/cluster/RedisShards.scala
@@ -278,6 +278,7 @@ abstract class RedisShards(val hosts: List[ClusterNode]) extends RedisCommand {
    * HashOperations
    */
   override def hset(key: Any, field: Any, value: Any)(implicit format: Format) = processForKey(key)(_.hset(key, field, value))
+  override def hset1(key: Any, field: Any, value: Any)(implicit format: Format) = processForKey(key)(_.hset1(key, field, value))
   override def hget[A](key: Any, field: Any)(implicit format: Format, parse: Parse[A]) = processForKey(key)(_.hget[A](key, field))
   override def hmset(key: Any, map: Iterable[Product2[Any, Any]])(implicit format: Format) = processForKey(key)(_.hmset(key, map))
   override def hmget[K,V](key: Any, fields: K*)(implicit format: Format, parseV: Parse[V]) = processForKey(key)(_.hmget[K,V](key, fields:_*))

--- a/src/test/scala/com/redis/HashOperationsSpec.scala
+++ b/src/test/scala/com/redis/HashOperationsSpec.scala
@@ -32,6 +32,16 @@ class HashOperationsSpec extends FunSpec
       r.hset("hash1", "field1", "val")
       r.hget("hash1", "field1") should be(Some("val"))
     }
+
+    it("should return true if field did not exist and was inserted") {
+      r.hdel("hash1", "field1")
+      r.hset("hash1", "field1", "val") should be(true)
+    }
+
+    it("should return false if field existed before and was overwritten") {
+      r.hset("hash1", "field1", "val")
+      r.hset("hash1", "field1", "val") should be(false)
+    }
     
     it("should set and get maps") {
       r.hmset("hash2", Map("field1" -> "val1", "field2" -> "val2"))
@@ -80,6 +90,23 @@ class HashOperationsSpec extends FunSpec
       r.hset("hash1", "field1", "abc")
       val thrown = the [Exception] thrownBy { r.hincrbyfloat("hash1", "field1", 2.0e2f) }
       thrown.getMessage should include("hash value is not a valid float")
+    }
+  }
+
+  describe("hset1") {
+    it("should set field") {
+      r.hset1("hash1", "field1", "val")
+      r.hget("hash1", "field1") should be(Some("val"))
+    }
+
+    it("should return Some(1) if field did not exist and was inserted") {
+      r.hdel("hash1", "field1")
+      r.hset1("hash1", "field1", "val") should be(Some(1L))
+    }
+
+    it("should return Some(0) if field existed before and was overwritten") {
+      r.hset1("hash1", "field1", "val")
+      r.hset1("hash1", "field1", "val") should be(Some(0L))
     }
   }
 

--- a/src/test/scala/com/redis/HashOperationsSpec.scala
+++ b/src/test/scala/com/redis/HashOperationsSpec.scala
@@ -99,12 +99,12 @@ class HashOperationsSpec extends FunSpec
       r.hget("hash1", "field1") should be(Some("val"))
     }
 
-    it("should return Some(1) if field did not exist and was inserted") {
+    it("should return Some(1L) if field did not exist and was inserted") {
       r.hdel("hash1", "field1")
       r.hset1("hash1", "field1", "val") should be(Some(1L))
     }
 
-    it("should return Some(0) if field existed before and was overwritten") {
+    it("should return Some(0L) if field existed before and was overwritten") {
       r.hset1("hash1", "field1", "val")
       r.hset1("hash1", "field1", "val") should be(Some(0L))
     }


### PR DESCRIPTION
Fix for #100 
According to  [HSET specification](http://redis.io/commands/hset) the reply should be:

> Integer reply, specifically:
> 1 if field is a new field in the hash and value was set.
> 0 if field already exists in the hash and the value was updated.

Currently, `HashOperations.hset` returns `Boolean`, which is obtained like this:

```scala
 case Some(n: Int) => n > 0
 case Some(s: Array[Byte]) => Parsers.parseString(s) match {
      case "OK" => true
      case "QUEUED" => true
      case _ => false
    }
 case _ => false
```

So, if the key was not present in Redis, the result is `true`. But if it was already present and overwritten, the result is `false`. 

I think that the last case (return `false` for existing key) is kinda confusing, because end user naturally expects `true`/`false` to indicate if operation was completed successfully or if it failed. 

There are methods `hsetnx` and `hmset` in `HashOperations` that return `Boolean`, but those methods do actually return the status of operation performed. In case of [HSET](http://redis.io/commands/hset), the meaning of Integer reply from Redis is different to [HSETNX](http://redis.io/commands/hsetnx) ( [HMSET](http://redis.io/commands/hmset) replies as String).
