### PR TITLE
fixed NPE after clearFD

### DIFF
--- a/src/main/scala/com/redis/IO.scala
+++ b/src/main/scala/com/redis/IO.scala
@@ -84,7 +84,7 @@ trait IO extends Log {
     var found: List[Int] = Nil
     var build = new scala.collection.mutable.ArrayBuilder.ofByte
     try {
-      while (delimiter != Nil) {
+      while (delimiter != Nil && in != null) {
         val next = in.read
         if (next < 0) return null
         if (next == delimiter.head) {


### PR DESCRIPTION
I got `NullPointerException` after call `RedisClient#disconnect` using PubSub.
Stacktrace is below.

```
java.lang.NullPointerException: null
        at com.redis.IO$class.readLine(IO.scala:88)
        at com.redis.RedisClient.readLine(RedisClient.scala:94)
        at com.redis.Reply$class.receive(RedisProtocol.scala:120)
        at com.redis.RedisClient.receive(RedisClient.scala:94)
        at com.redis.R$class.asList(RedisProtocol.scala:151)
        at com.redis.RedisClient.asList(RedisClient.scala:94)
        at com.redis.PubSub$Consumer$$anonfun$run$1.apply$mcV$sp(PubSub.scala:34)
        at com.redis.Util$.whileTrue(PubSub.scala:9)
        at com.redis.PubSub$Consumer.run(PubSub.scala:33)
        at java.lang.Thread.run(Thread.java:745)
```