### PR TITLE
Add spop with count since redis 3.2

### DIFF
--- a/src/main/scala/com/redis/SetOperations.scala
+++ b/src/main/scala/com/redis/SetOperations.scala
@@ -19,6 +19,11 @@ trait SetOperations { self: Redis =>
   def spop[A](key: Any)(implicit format: Format, parse: Parse[A]): Option[A] =
     send("SPOP", List(key))(asBulk)
 
+  // SPOP
+  // Remove and return multiple random elements (pop) from the Set value at key since (3.2).
+  def spop[A](key: Any, count: Int)(implicit format: Format, parse: Parse[A]): Option[Set[Option[A]]] =
+    send("SPOP", List(key, count))(asSet)
+
   // SMOVE
   // Move the specified member from one Set to another atomically.
   def smove(sourceKey: Any, destKey: Any, value: Any)(implicit format: Format): Option[Long] =
@@ -40,7 +45,7 @@ trait SetOperations { self: Redis =>
     send("SINTER", key :: keys.toList)(asSet)
 
   // SINTERSTORE
-  // Compute the intersection between the Sets stored at key1, key2, ..., keyN, 
+  // Compute the intersection between the Sets stored at key1, key2, ..., keyN,
   // and store the resulting Set at dstkey.
   // SINTERSTORE returns the size of the intersection, unlike what the documentation says
   // refer http://code.google.com/p/redis/issues/detail?id=121
@@ -53,7 +58,7 @@ trait SetOperations { self: Redis =>
     send("SUNION", key :: keys.toList)(asSet)
 
   // SUNIONSTORE
-  // Compute the union between the Sets stored at key1, key2, ..., keyN, 
+  // Compute the union between the Sets stored at key1, key2, ..., keyN,
   // and store the resulting Set at dstkey.
   // SUNIONSTORE returns the size of the union, unlike what the documentation says
   // refer http://code.google.com/p/redis/issues/detail?id=121
@@ -66,7 +71,7 @@ trait SetOperations { self: Redis =>
     send("SDIFF", key :: keys.toList)(asSet)
 
   // SDIFFSTORE
-  // Compute the difference between the Set key1 and all the Sets key2, ..., keyN, 
+  // Compute the difference between the Set key1 and all the Sets key2, ..., keyN,
   // and store the resulting Set at dstkey.
   def sdiffstore(key: Any, keys: Any*)(implicit format: Format): Option[Long] =
     send("SDIFFSTORE", key :: keys.toList)(asLong)

--- a/src/test/scala/com/redis/SetOperationsSpec.scala
+++ b/src/test/scala/com/redis/SetOperationsSpec.scala
@@ -9,7 +9,7 @@ import org.junit.runner.RunWith
 
 
 @RunWith(classOf[JUnitRunner])
-class SetOperationsSpec extends FunSpec 
+class SetOperationsSpec extends FunSpec
                         with Matchers
                         with BeforeAndAfterEach
                         with BeforeAndAfterAll {
@@ -87,6 +87,27 @@ class SetOperationsSpec extends FunSpec
     }
     it("should return nil if the key does not exist") {
       r.spop("set-1") should equal(None)
+    }
+  }
+
+  describe("spop with count") {
+    it("should pop a list of random members") {
+      r.sadd("set-1", "one").get should equal(1)
+      r.sadd("set-1", "two").get should equal(1)
+      r.sadd("set-1", "three").get should equal(1)
+      r.sadd("set-1", "four").get should equal(1)
+      r.sadd("set-1", "five").get should equal(1)
+      r.sadd("set-1", "six").get should equal(1)
+      r.sadd("set-1", "seven").get should equal(1)
+      r.sadd("set-1", "eight").get should equal(1)
+
+      r.spop("set-1", 2).get.size should equal(2)
+
+      // if supplied count > size, then whole set is returned
+      r.spop("set-1", 24).get.size should equal(6)
+
+      // if empty, returned set is empty
+      r.spop("set-1", 5).get shouldBe empty
     }
   }
 
@@ -171,7 +192,7 @@ class SetOperationsSpec extends FunSpec
       r.sadd("set-1", "foo").get should equal(1)
       r.sadd("set-1", "bar").get should equal(1)
       r.sadd("set-1", "baz").get should equal(1)
-      r.sinter("set-1", "set-4") should equal(Some(Set())) 
+      r.sinter("set-1", "set-4") should equal(Some(Set()))
     }
   }
 


### PR DESCRIPTION
What does this PR do?

- Adds new method `spop` with count. Returns members as `Some(Set())`.
- Other changes are due to trailing whitespace.

Impact?
- New method

Test?
- `sbt test` -- I verified `spop` with count specs pass.