### PR TITLE
Scala 2.13.0-M4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
   organization := "net.debasishg",
   version := "3.7",
   scalaVersion := "2.11.12",
-  crossScalaVersions := Seq("2.12.6", "2.11.12", "2.10.7"),
+  crossScalaVersions := Seq("2.12.6", "2.11.12", "2.10.7", "2.13.0-M4"),
 
   scalacOptions in Compile ++= Seq( "-unchecked", "-feature", "-language:postfixOps", "-deprecation" ),
 
@@ -20,10 +20,10 @@ lazy val coreSettings = commonSettings ++ Seq(
   libraryDependencies ++= Seq(
     "commons-pool"      %  "commons-pool"            % "1.6",
     "org.slf4j"         %  "slf4j-api"               % "1.7.25",
-    "org.slf4j"         %  "slf4j-log4j12"           % "1.7.25"     % "provided",
-    "log4j"             %  "log4j"                   % "1.2.17"     % "provided",
-    "junit"             %  "junit"                   % "4.12"       % "test",
-    "org.scalatest"     %%  "scalatest"              % "3.0.4"      % "test"),
+    "org.slf4j"         %  "slf4j-log4j12"           % "1.7.25"      % "provided",
+    "log4j"             %  "log4j"                   % "1.2.17"      % "provided",
+    "junit"             %  "junit"                   % "4.12"        % "test",
+    "org.scalatest"     %%  "scalatest"              % "3.0.6-SNAP2" % "test"),
 
   parallelExecution in Test := false,
   publishTo := version { (v: String) =>

--- a/src/test/scala/com/redis/cluster/RedisClusterSpec.scala
+++ b/src/test/scala/com/redis/cluster/RedisClusterSpec.scala
@@ -8,7 +8,9 @@ import org.scalatest.junit.JUnitRunner
 import org.junit.runner.RunWith
 import com.redis.RedisClient
 import com.redis.serialization.Format
+
 import collection.mutable.WrappedArray
+import scala.collection.mutable
 
 
 @RunWith(classOf[JUnitRunner])
@@ -18,7 +20,7 @@ class RedisClusterSpec extends FunSpec
                        with BeforeAndAfterAll {
 
   val nodes = Array(ClusterNode("node1", "localhost", 6379), ClusterNode("node2", "localhost", 6380), ClusterNode("node3", "localhost", 6381))
-  val r = new RedisCluster(new WrappedArray.ofRef(nodes): _*) {
+  val r = new RedisCluster(new mutable.WrappedArray.ofRef(nodes).toSeq: _*) {
     val keyTag = Some(RegexKeyTag)
   }
 
@@ -104,7 +106,7 @@ class RedisClusterSpec extends FunSpec
     }
 
     it("replace node should not change hash ring order"){
-      val r = new RedisCluster(new WrappedArray.ofRef(nodes): _*) {
+      val r = new RedisCluster(new WrappedArray.ofRef(nodes).toSeq: _*) {
 		  val keyTag = Some(RegexKeyTag)
 	  }
       r.set("testkey1", "testvalue2")
@@ -130,7 +132,7 @@ class RedisClusterSpec extends FunSpec
     }
     
     it("remove failure node should change hash ring order so that key on failure node should be served by other running nodes"){
-	  val r = new RedisCluster(new WrappedArray.ofRef(nodes): _*) {
+	  val r = new RedisCluster(new WrappedArray.ofRef(nodes).toSeq: _*) {
 		  val keyTag = Some(RegexKeyTag)
 	  }
       r.set("testkey1", "testvalue2")
@@ -147,7 +149,7 @@ class RedisClusterSpec extends FunSpec
     }
     
     it("list nodes should return the running nodes but not configured nodes"){
-      val r = new RedisCluster(new WrappedArray.ofRef(nodes): _*) {
+      val r = new RedisCluster(new WrappedArray.ofRef(nodes).toSeq: _*) {
 		  val keyTag = Some(RegexKeyTag)
 	  }
       r.listServers.toSet should equal (nodes.toSet)

--- a/src/test/scala/com/redis/cluster/RedisClusterSpec.scala
+++ b/src/test/scala/com/redis/cluster/RedisClusterSpec.scala
@@ -10,7 +10,6 @@ import com.redis.RedisClient
 import com.redis.serialization.Format
 
 import collection.mutable.WrappedArray
-import scala.collection.mutable
 
 
 @RunWith(classOf[JUnitRunner])
@@ -20,7 +19,7 @@ class RedisClusterSpec extends FunSpec
                        with BeforeAndAfterAll {
 
   val nodes = Array(ClusterNode("node1", "localhost", 6379), ClusterNode("node2", "localhost", 6380), ClusterNode("node3", "localhost", 6381))
-  val r = new RedisCluster(new mutable.WrappedArray.ofRef(nodes).toSeq: _*) {
+  val r = new RedisCluster(new WrappedArray.ofRef(nodes).toSeq: _*) {
     val keyTag = Some(RegexKeyTag)
   }
 


### PR DESCRIPTION
## Motivation

- Getting ready to work with Scala 2.13.0

## Notice

Now, Scala 2.13.0-M5 IS NOW AVAILABLE. but `scalatest` running in Scala 2.13.0-M5  has not been released yet. so I use Scala 2.13.0-M4

https://www.scala-lang.org/news/2.13.0-M5
https://github.com/scalatest/scalatest/issues/1409
