### PR TITLE
feat(CI): add openjdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ scala:
   - 2.13.0
 jdk:
   - openjdk8
+  - openjdk11
 services:
   - redis-server
 before_script:

--- a/src/test/scala/com/redis/Bench.scala
+++ b/src/test/scala/com/redis/Bench.scala
@@ -36,7 +36,7 @@ object Bench {
   def load(opsPerClient: Int, fn: (Int, String) => Unit)(implicit clients: RedisClientPool): (Double, Double, Seq[_]) = {
     val start = System.nanoTime
     val tasks = (1 to 100) map (i => Future { fn(opsPerClient, "k" + i.toString) })
-    val results = Await.result(Future.sequence(tasks), 60 seconds)
+    val results = Await.result(Future.sequence(tasks), 75 seconds)
     val elapsedSeconds = (System.nanoTime - start)/1000000000.0 
     val opsPerSec = (opsPerClient * 100 * 2) / elapsedSeconds
     (elapsedSeconds, opsPerSec, results)

--- a/src/test/scala/com/redis/StringOperationsSpec.scala
+++ b/src/test/scala/com/redis/StringOperationsSpec.scala
@@ -47,14 +47,14 @@ with BeforeAndAfterAll {
 
   describe("set if exists or not") {
     it("should set key/value pairs with exclusiveness and expire") {
-      r.set("amit-1", "mor", false, Seconds(6))
-      r.get("amit-1") match {
+      r.set("amit-2", "mor", false, Seconds(6))
+      r.get("amit-2") match {
         case Some(s: String) => s should equal("mor")
         case None => fail("should return mor")
       }
       Thread.sleep(6000)
-      r.get("amit-1") should equal(None)
-      r.del("amit-1")
+      r.get("amit-2") should equal(None)
+      r.del("amit-2")
     }
   }
 

--- a/src/test/scala/com/redis/StringOperationsSpec.scala
+++ b/src/test/scala/com/redis/StringOperationsSpec.scala
@@ -1,5 +1,6 @@
 package com.redis
 
+import java.util.concurrent.TimeUnit
 import org.scalatest.FunSpec
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.BeforeAndAfterAll
@@ -52,7 +53,7 @@ with BeforeAndAfterAll {
         case Some(s: String) => s should equal("mor")
         case None => fail("should return mor")
       }
-      Thread.sleep(6000)
+      TimeUnit.SECONDS.sleep(6)
       r.get("amit-2") should equal(None)
       r.del("amit-2")
     }


### PR DESCRIPTION
## Motivation

In order to check that it run in the environment of `openjdk11`,
Added setting for travisCI.

https://www.scala-lang.org/2019/01/18/community-build.html