### PR TITLE
Fix commonly failing tests and adjusted travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: scala
 dist: xenial
 scala:
-  - 2.12.8
-  - 2.11.12
   - 2.13.0
 script:
-  - travis_retry sbt "++${TRAVIS_SCALA_VERSION}" test
+  - sbt +test
 jdk:
   - openjdk8
   - openjdk11

--- a/src/test/scala/com/redis/Bench.scala
+++ b/src/test/scala/com/redis/Bench.scala
@@ -36,7 +36,7 @@ object Bench {
   def load(opsPerClient: Int, fn: (Int, String) => Unit)(implicit clients: RedisClientPool): (Double, Double, Seq[_]) = {
     val start = System.nanoTime
     val tasks = (1 to 100) map (i => Future { fn(opsPerClient, "k" + i.toString) })
-    val results = Await.result(Future.sequence(tasks), 75 seconds)
+    val results = Await.result(Future.sequence(tasks), 120 seconds)
     val elapsedSeconds = (System.nanoTime - start)/1000000000.0 
     val opsPerSec = (opsPerClient * 100 * 2) / elapsedSeconds
     (elapsedSeconds, opsPerSec, results)

--- a/src/test/scala/com/redis/PatternsSpec.scala
+++ b/src/test/scala/com/redis/PatternsSpec.scala
@@ -14,15 +14,15 @@ class PatternsSpec extends FunSpec
 
   implicit val clients = new RedisClientPool("localhost", 6379)
 
-  override def beforeEach = {
-  }
-
   override def afterEach = clients.withClient{
     client => client.flushdb
   }
 
   override def afterAll = {
-    clients.withClient{ client => client.disconnect }
+    clients.withClient{ client =>
+      client.flushall
+      client.disconnect
+    }
     clients.close
   }
 

--- a/src/test/scala/com/redis/PipelineSpec.scala
+++ b/src/test/scala/com/redis/PipelineSpec.scala
@@ -24,12 +24,17 @@ class PipelineSpec extends FunSpec
 
   describe("pipeline1 with publish") {
     it("should do pipelined commands") {
-      r.pipeline { p =>
+      val res = r.pipeline { p =>
         p.set("key", "debasish")
         p.get("key")
         p.get("key1")
         p.publish("a", "debasish ghosh")
-      }.get should equal(List(true, Some("debasish"), None, Some(0)))
+      }.get
+
+      inside(res) {
+        case List(true, Some("debasish"), None, Some(_)) => succeed
+        case _ => fail
+      }
     }
   }
 
@@ -77,7 +82,10 @@ class PipelineSpec extends FunSpec
       p.get("key1")
     }.get
 
-    inside(res) { case List(true, Some(_), Some("debasish"), Some(_), None) => }
+    inside(res) {
+      case List(true, Some(_), Some("debasish"), Some(_), None) => succeed
+      case _ => fail
+    }
   }
 
   import scala.concurrent.Await

--- a/src/test/scala/com/redis/StringOperationsSpec.scala
+++ b/src/test/scala/com/redis/StringOperationsSpec.scala
@@ -32,11 +32,9 @@ with IntSpec {
 
   describe("set if exists or not") {
     it("should set key/value pairs with exclusiveness and expire") {
-      r.set("amit-2", "mor", false, Seconds(6))
-      r.get("amit-2") match {
-        case Some(s: String) => s should equal("mor")
-        case None => fail("should return mor")
-      }
+      r.set("amit-2", "mor", false, Seconds(5))
+      r.get("amit-2").get should equal("mor")
+
       TimeUnit.SECONDS.sleep(6)
       r.get("amit-2") should equal(None)
       r.del("amit-2")

--- a/src/test/scala/com/redis/WatchSpec.scala
+++ b/src/test/scala/com/redis/WatchSpec.scala
@@ -4,52 +4,52 @@ import org.scalatest.FunSpec
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.Matchers
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Milliseconds, Seconds => SSeconds, Span}
 
-class WatchSpec extends FunSpec
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class WatchSpec extends FunSpec with ScalaFutures
                      with Matchers
                      with BeforeAndAfterEach
                      with BeforeAndAfterAll {
 
-  implicit val clients = new RedisClientPool("localhost", 6379)
+  implicit val pc: PatienceConfig = PatienceConfig(Span(5, SSeconds), Span(100, Milliseconds))
 
-  override def beforeEach = {
+  val clients: RedisClientPool = new RedisClientPool("localhost", 6379)
+
+  override def beforeAll(): Unit = {
+    clients.withClient(_.flushall)
   }
 
-  override def afterEach = clients.withClient{
-    client => client.flushdb
-  }
-
-  override def afterAll = {
-    clients.withClient{ client => client.disconnect }
+  override def afterAll(): Unit = {
     clients.close
   }
 
   describe("watch") {
     it("should fail a transaction if modified from another client") {
-      implicit val clients = new RedisClientPool("localhost", 6379)
-      class P1 extends Runnable {
-        def run(): Unit = {
-          clients.withClient { client =>
-            client.watch("key")
-            client.pipeline { p =>
-              p.set("key", "debasish")
-              Thread.sleep(50)
-              p.get("key")
-              p.get("key1")
-            } should equal(None)
+      val p1: Future[Option[List[Any]]] = Future {
+        clients.withClient { client =>
+          client.watch("key")
+          client.pipeline { p =>
+            p.set("key", "debasish")
+            Thread.sleep(50)
+            p.get("key")
+            p.get("key1")
           }
+      }
+      }
+
+      val p2: Future[Boolean] = Future {
+        clients.withClient { client =>
+          Thread.sleep(10)
+          client.set("key", "anshin")
         }
       }
-      class P2 extends Runnable {
-        def run(): Unit = {
-          clients.withClient { client =>
-            Thread.sleep(10)
-            client.set("key", "anshin")
-          }
-        }
-      }
-      new Thread(new P1()).start()
-      new Thread(new P2()).start()
+
+      p2.futureValue should equal(true)
+      p1.futureValue should equal(None)
     }
   }
 }


### PR DESCRIPTION
This is what I have done:

- `PipelineSpec` had an assertion that sometimes would fail `Some(0)` depending on client response. Also, fail checks were missing
- `Bench` had too short timeout, and somtimes failed. 
- `StringOperationsSpec`timeout is same as TTL, which would sometimes fail
- `ListOperationsSpec` blocking ops in external `Runnable` are nasty code. Fixed with `Future` and blocking `futureValue`
- `BlockingDequeSpec` is the same case as `ListOperationsSpec`
- `WatchSpec` - the same as `ListOperationsSpec`
- `PatternsSpec` did not clean up after tests
- `PubSubSpec` had a test that kept the connection alive, and actually is not a test

About travis:

- specifying scala versions spawned multiple machines, however, you can cross-compile using newest scala to older versions. Or the other way round too. Sbt will download the proper version for you.
- running sbt with `++{scalaVersion}` also ommited `2.10` build which is specified in the `sbt`. I think it is best to simply let the sbt do the job.
- I removed the retry, because the tests should not fail randomly. this needs to be stable.


This can be merged before others, I will handle the conflicts.