### PR TITLE
Create reconnectable trait for redis cluster 

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,3 @@
+-J-Xmx3g
+-J-XX:MaxMetaspaceSize=512m
+#-Dsbt.task.timings=true

--- a/README.md
+++ b/README.md
@@ -234,6 +234,27 @@ def scatterGatherFirstWithList(opsPerClient: Int)(implicit clients: RedisClientP
 
 See an example implementation using Akka at https://github.com/debasishg/akka-redis-pubsub.
 
+## RedisCluster
+
+`RedisCluster` uses data sharding (partitioning) which splits all data across available Redis instances, 
+so that every instance contains only a subset of the keys. Such process allows mitigating data grown 
+by adding more and more instances and dividing the data to smaller parts (shards or partitions). 
+
+`RedisCluster` allows user to pass a special `KeyTag`, that helps to distribute keys according to special
+requirements. Otherwise node is selected by hashing the whole key with `CRC-32` function.
+
+`RedisCluster` also allows for dynamic nodes modification with `addServer`, `replaceServer` and `removeServer` 
+methods. Note that data on the disconnected node will be lost immediately.
+What is more, since modification of the cluster impacts key distribution, some of the data scattered 
+across the cluster could be lost as well.
+
+For automatic node downtime handling, by disconnecting the offline node and reconnecting it as it comes back up,
+there is a `Reconnectable` trait. To allow such behaviour mix it into `RedisCluster` instance:
+```
+new RedisCluster(nodes, Some(NoOpKeyTag)) with Reconnectable
+```
+you can observe it's behaviour in `ReconnectableSpec` test.
+
 ## License
 
 This software is licensed under the Apache 2 license, quoted below.

--- a/src/main/scala/com/redis/cluster/KeyTag.scala
+++ b/src/main/scala/com/redis/cluster/KeyTag.scala
@@ -1,31 +1,28 @@
 package com.redis.cluster
 
 /**
+ * <p>
  * Consistent hashing distributes keys across multiple servers. But there are situations
  * like <i>sorting</i> or computing <i>set intersections</i> or operations like <tt>rpoplpush</tt>
  * in redis that require all keys to be collocated on the same server.
- * <p/>
- * One of the techniques that redis encourages for such forced key locality is called
- * <i>key tagging</i>. See <http://code.google.com/p/redis/wiki/FAQ> for reference.
- * <p/>
- * The trait <tt>KeyTag</tt> defines a method <tt>tag</tt> that takes a key and returns
- * the part of the key on which we hash to determine the server on which it will be located.
- * If it returns <tt>None</tt> then we hash on the whole key, otherwise we hash only on the
- * returned part.
- * <p/>
- * redis-rb implements a regex based trick to achieve key-tagging. Here is the technique
- * explained in redis FAQ:
- * <i>
- * A key tag is a special pattern inside a key that, if preset, is the only part of the key
- * hashed in order to select the server for this key. For example in order to hash the key
- * "foo" I simply perform the CRC32 checksum of the whole string, but if this key has a
- * pattern in the form of the characters {...} I only hash this substring. So for example
- * for the key "foo{bared}" the key hashing code will simply perform the CRC32 of "bared".
- * This way using key tags you can ensure that related keys will be stored on the same Redis
- * instance just using the same key tag for all this keys. Redis-rb already implements key tags.
- * </i>
+ * </p>
+ * <p>
+ * One of the techniques that redis encourages for such forced key locality is called <i>key tagging</i>.
+ * See <a href="https://redis.io/topics/cluster-tutorial#redis-cluster-data-sharding">Redis Cluster data sharding</a>
+ * for reference.
+ * </p>
+ * <p><i>
+ * (...) but the gist is that if there is a substring between {} brackets in a key, only what is inside the string
+ * is hashed, so for example this{foo}key and another{foo}key are guaranteed to be in the same hash slot,
+ * and can be used together in a command with multiple keys as arguments.
+ * </i></p>
  */
 trait KeyTag {
+
+  /**
+   * Takes a key and returns the part of the key on which we hash to determine the server on which it will be located.
+   * If it returns <tt>None</tt> then we hash on the whole key, otherwise we hash only on the returned part.
+   */
   def tag(key: Seq[Byte]): Option[Seq[Byte]]
 }
 
@@ -46,7 +43,7 @@ object KeyTag {
   }
 
   object NoOpKeyTag extends KeyTag {
-    def tag(key: Seq[Byte]) = Some(key)
+    def tag(key: Seq[Byte]): Option[Seq[Byte]] = None
   }
 
 }

--- a/src/main/scala/com/redis/cluster/Reconnectable.scala
+++ b/src/main/scala/com/redis/cluster/Reconnectable.scala
@@ -1,0 +1,63 @@
+package com.redis.cluster
+
+import java.util.concurrent.{Executors, ScheduledExecutorService, TimeUnit}
+
+import com.redis.Log
+import com.redis.api.BaseApi
+
+import scala.collection.mutable
+import scala.util.{Failure, Success, Try}
+
+trait Reconnectable extends Log {
+  rc: RedisClusterOps with AutoCloseable with BaseApi with WithHashRing[IdentifiableRedisClientPool] =>
+
+  protected[cluster] val disconnectedNodes: mutable.Set[ClusterNode] = createSet[ClusterNode]()
+  protected[cluster] val scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(1)
+
+  protected lazy val checkIntervalSeconds: Int = 15
+
+  protected[cluster] def disconnectInactive(): Unit = {
+    val unreachable = hr.cluster.filterNot(n =>
+      Try(n.withClient(_.ping) == pong).getOrElse(false))
+
+    unreachable.foreach { node =>
+      info(s"Disconnecting $node")
+      disconnectedNodes.add(node.node)
+      removeServer(node.node.nodename)
+    }
+
+  }
+
+  protected[cluster] def tryToReconnect(): Unit = {
+    val reconnected = disconnectedNodes.filter { node =>
+      addServer(node) match {
+        case Success(_) =>
+          true
+        case Failure(e) =>
+          error(s"Failed to reconnect node [${node.nodename}] to cluster, because [${e.getMessage}]", e)
+          false
+      }
+    }
+    reconnected.foreach { node =>
+      info(s"Reconnecting $node")
+      disconnectedNodes.remove(node)
+    }
+  }
+
+  scheduler.scheduleAtFixedRate(new Runnable {
+    override def run(): Unit = Try {
+      debug(s"Nodes in cluster: [${hr.cluster.mkString(",")}]")
+      debug(s"Disconnected nodes: [${disconnectedNodes.mkString(",")}]")
+      tryToReconnect()
+      disconnectInactive()
+    }.recover {
+      case e => error(e.getMessage, e)
+    }
+  }, checkIntervalSeconds, checkIntervalSeconds, TimeUnit.SECONDS)
+
+  override def close(): Unit = {
+    scheduler.shutdown()
+    hr.cluster.foreach(_.close())
+  }
+
+}

--- a/src/main/scala/com/redis/cluster/RedisClusterOps.scala
+++ b/src/main/scala/com/redis/cluster/RedisClusterOps.scala
@@ -3,7 +3,7 @@ package com.redis.cluster
 import com.redis.serialization.Format
 import com.redis.{RedisClient, RedisClientPool, RedisCommand}
 
-import scala.util.Random
+import scala.util.{Random, Try}
 
 trait RedisClusterOps extends AutoCloseable {
 
@@ -25,7 +25,7 @@ trait RedisClusterOps extends AutoCloseable {
   /**
    * add server to internal pool
    */
-  def addServer(server: ClusterNode): Unit
+  def addServer(server: ClusterNode): Try[Unit]
 
   /**
    * replace a server

--- a/src/main/scala/com/redis/cluster/package.scala
+++ b/src/main/scala/com/redis/cluster/package.scala
@@ -1,5 +1,7 @@
 package com.redis
 
+import scala.collection.mutable
+
 package object cluster {
 
   /**
@@ -13,6 +15,11 @@ package object cluster {
   class IdentifiableRedisClientPool(val node: ClusterNode)
     extends RedisClientPool(node.host, node.port, node.maxIdle, node.database, node.secret, node.timeout) {
     override def toString: String = node.nodename
+  }
+
+  protected[cluster] def createSet[T](): mutable.Set[T] = {
+    import scala.collection.JavaConverters._
+    java.util.Collections.newSetFromMap(new java.util.concurrent.ConcurrentHashMap[T, java.lang.Boolean]).asScala
   }
 
 }

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,13 +1,12 @@
-# for production, you should probably set the root to INFO
-# and the pattern to %c instead of %l.  (%l is slower.)
-
-# output messages into a rolling log file as well as stdout
-/*log4j.rootLogger=INFO,stdout*/
+log4j.rootLogger=DEBUG,stdout
 
 # stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%5p [%t] %d{HH:mm:ss,SSS} %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %c - %m%n
 
 # Application logging options
-log4j.logger.com.redis=INFO,stdout
+log4j.logger.com.redis=INFO
+log4j.logger.com.redis.cluster=DEBUG
+log4j.logger.com.github.dockerjava=INFO
+log4j.logger.org.apache.http=INFO

--- a/src/test/scala/com/redis/WatchSpec.scala
+++ b/src/test/scala/com/redis/WatchSpec.scala
@@ -17,7 +17,7 @@ class WatchSpec extends FunSpec
           client.watch("key")
           client.pipeline { p =>
             p.set("key", "debasish")
-            Thread.sleep(100)
+            Thread.sleep(500)
             p.get("key")
             p.get("key1")
           }
@@ -26,7 +26,7 @@ class WatchSpec extends FunSpec
 
       val p2: Future[Boolean] = Future {
         clients.withClient { client =>
-          Thread.sleep(10)
+          Thread.sleep(50)
           client.set("key", "anshin")
         }
       }

--- a/src/test/scala/com/redis/cluster/ReconnectableSpec.scala
+++ b/src/test/scala/com/redis/cluster/ReconnectableSpec.scala
@@ -1,0 +1,114 @@
+package com.redis.cluster
+
+import com.redis.cluster.KeyTag.NoOpKeyTag
+import com.redis.common.IntClusterSpec
+import com.whisk.docker.DockerContainer
+import org.scalatest.{FunSpec, GivenWhenThen, Matchers, Suite}
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.{Future, Promise}
+import scala.util.Try
+
+class ReconnectableSpec extends FunSpec with GivenWhenThen
+  with ControlledDockerRedisCluster {
+
+  override protected lazy val r: RedisCluster with Reconnectable = new RedisCluster(nodes, Some(NoOpKeyTag)) with Reconnectable {
+    override protected lazy val checkIntervalSeconds: Int = 1
+  }
+
+  describe("reconnectable cluster") {
+    it("should properly disconnect and reconnect node") {
+      Given("Initial cluster")
+      When("Evertything is running")
+
+      val nodeName0 = s"${nodeNamePrefix}0"
+      val initialKeyNodeMap = Map(
+        "abc4" -> nodeName0,
+        "abc8" -> s"${nodeNamePrefix}1",
+        "abc7" -> s"${nodeNamePrefix}2",
+        "abc0" -> s"${nodeNamePrefix}3"
+      )
+
+      Then("The keys are mapped to all nodes")
+      initialKeyNodeMap.foreach { case (k, v) =>
+        val node = r.nodeForKey(k)
+        node.node.nodename should be(v)
+
+        r.set(k, v) should be(true)
+        r.get(k).get should be(v)
+        r.del(k).get should be(1)
+      }
+
+      When("One node is stopped")
+      stopContainer0()
+
+      Then("The cluster should re-balance with one node less")
+      waitForCluster(!_.exists(_.nodename == nodeName0)).futureValue should be(true)
+      initialKeyNodeMap.foreach { case (k, v) =>
+        val node = r.nodeForKey(k)
+        node.node.nodename should not be (container0Name)
+
+        r.set(k, v) should be(true)
+        r.get(k).get should be(v)
+        r.del(k).get should be(1)
+      }
+
+      When("The node comes back up")
+      startContainer0()
+
+      Then("The cluster should re-balance with new node")
+      waitForCluster(_.exists(_.nodename == nodeName0)).futureValue should be(true)
+      initialKeyNodeMap.foreach { case (k, v) =>
+        val node = r.nodeForKey(k)
+        node.node.nodename should be(v)
+
+        r.set(k, v) should be(true)
+        r.get(k).get should be(v)
+        r.del(k).get should be(1)
+      }
+    }
+  }
+
+  def waitForCluster(expected: List[ClusterNode] => Boolean, remaining: Int = 10,
+                     p: Promise[Boolean] = Promise[Boolean]): Future[Boolean] =
+    if (expected(r.listServers)) {
+      p.success(true).future
+    } else if (remaining > 0) {
+      Thread.sleep(1000)
+      waitForCluster(expected, remaining - 1, p)
+    } else {
+      p.failure(new Throwable("Did not reach expected state")).future
+    }
+
+  override def afterAll(): Unit = {
+    r.close()
+    Try(dockerExecutor.remove(container0Name).futureValue)
+    containerNames.foreach(i => Try(dockerExecutor.remove(i).futureValue))
+    super.afterAll()
+  }
+}
+
+trait ControlledDockerRedisCluster extends IntClusterSpec with Matchers {
+  that: Suite =>
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  protected lazy val container0: DockerContainer = runningContainers.head
+  protected lazy val container0Name: String = container0.name.get
+  protected lazy val container0Ports: Map[Int, Int] = container0.getPorts().futureValue
+  protected lazy val newContainer0: DockerContainer = createContainer(Some(container0Name), container0Ports)
+
+  protected lazy val containerNames: List[String] = runningContainers.flatMap(_.name)
+
+  protected def startContainer0(): Unit = {
+    logger.info(s"Manually starting node [$container0Name], [$container0Ports]")
+    val new0Id = dockerExecutor.createContainer(newContainer0).futureValue
+    dockerExecutor.startContainer(new0Id).futureValue
+  }
+
+  protected def stopContainer0(): Unit = {
+    logger.info(s"Manually removing node [$container0Name], [$container0Ports]")
+    dockerExecutor.remove(container0Name).futureValue
+  }
+
+}

--- a/src/test/scala/com/redis/common/IntClusterSpec.scala
+++ b/src/test/scala/com/redis/common/IntClusterSpec.scala
@@ -9,7 +9,7 @@ trait IntClusterSpec extends BeforeAndAfterEach with RedisDockerCluster {
   that: Suite =>
 
   protected def r: BaseApi with AutoCloseable
-  private val nodeNamePrefix = "node"
+  protected val nodeNamePrefix = "node"
 
   protected lazy val nodes: List[ClusterNode] =
     runningContainers.zipWithIndex.map { case (c, i) =>

--- a/src/test/scala/com/redis/common/RedisDocker.scala
+++ b/src/test/scala/com/redis/common/RedisDocker.scala
@@ -43,8 +43,16 @@ trait RedisContainer extends DockerKit with DockerTestKit with DockerKitDockerJa
   protected val redisContainerHost: String = "localhost"
   protected val redisPort: Int = 6379
 
-  protected def createContainer(): DockerContainer =
-    DockerContainer("redis:latest", name = Some(RandomStringUtils.randomAlphabetic(10)))
-      .withPorts(redisPort -> None)
+  protected def createContainer(name: Option[String] = Some(RandomStringUtils.randomAlphabetic(10)),
+                                ports: Map[Int, Int] = Map.empty): DockerContainer = {
+    val containerPorts: Seq[(Int, Option[Int])] = if (ports.isEmpty) {
+      Seq((redisPort -> None))
+    } else {
+      ports.mapValues(i => Some(i)).toSeq
+    }
+
+    DockerContainer("redis:latest", name = name)
+      .withPorts(containerPorts: _*)
       .withReadyChecker(DockerReadyChecker.LogLineContains("Ready to accept connections"))
+  }
 }


### PR DESCRIPTION
When mixing in the `Reconnectable` trait it will allow a cluster to rebalance on "its own".
It is trying to reconnect to the nodes every "nth" second, by sending health check ping to the nodes.

Changes comments:
- `.sbtopts` because SBT likes to fail with metaspace exceptions on my local machine :cry: 
- `addServer(server: ClusterNode)` returned `Unit` but did not check if the node is actually working. So it could actually add a node that is not working.
- `logging.properties` - root logger was commented out :open_mouth: 

@debasishg is there any chance you would release a new version to maven anytime soon?

