### PR TITLE
adding all settings available to Cluster clients

### DIFF
--- a/src/main/scala/com/redis/Pool.scala
+++ b/src/main/scala/com/redis/Pool.scala
@@ -4,7 +4,6 @@ import java.util.concurrent.TimeUnit
 
 import org.apache.commons.pool2._
 import org.apache.commons.pool2.impl._
-import com.redis.cluster.ClusterNode
 
 private [redis] class RedisClientFactory(val host: String, val port: Int, val database: Int = 0, val secret: Option[Any] = None, val timeout : Int = 0)
   extends PooledObjectFactory[RedisClient] {
@@ -33,8 +32,16 @@ object RedisClientPool {
   val UNLIMITED_CONNECTIONS: Int = -1
 }
 
-class RedisClientPool(val host: String, val port: Int, val maxIdle: Int = 8, val database: Int = 0, val secret: Option[Any] = None, val timeout : Int = 0,
-                      val maxConnections: Int = RedisClientPool.UNLIMITED_CONNECTIONS, val poolWaitTimeout: Long = 3000) {
+class RedisClientPool(
+                       val host: String,
+                       val port: Int,
+                       val maxIdle: Int = 8,
+                       val database: Int = 0,
+                       val secret: Option[Any] = None,
+                       val timeout: Int = 0,
+                       val maxConnections: Int = RedisClientPool.UNLIMITED_CONNECTIONS,
+                       val poolWaitTimeout: Long = 3000
+                     ) {
 
   val objectPoolConfig = new GenericObjectPoolConfig[RedisClient]
   objectPoolConfig.setMaxIdle(maxIdle)

--- a/src/main/scala/com/redis/cluster/package.scala
+++ b/src/main/scala/com/redis/cluster/package.scala
@@ -8,14 +8,34 @@ package object cluster {
    * a level of abstraction for each node decoupling it from the address. A node is now identified
    * by a name, so functions like <tt>replaceServer</tt> works seamlessly.
    */
-  case class ClusterNode(nodename: String, host: String, port: Int, database: Int = 0, maxIdle: Int = 8, secret: Option[Any] = None, timeout: Int = 0) {
+  case class ClusterNode(
+                          nodename: String,
+                          host: String,
+                          port: Int,
+                          maxIdle: Int = 8,
+                          database: Int = 0,
+                          secret: Option[Any] = None,
+                          timeout: Int = 0,
+                          maxConnections: Int = RedisClientPool.UNLIMITED_CONNECTIONS,
+                          poolWaitTimeout: Long = 3000
+                        ) {
     assert(nodename.nonEmpty)
 
     override def toString: String = nodename
   }
 
   class IdentifiableRedisClientPool(val node: ClusterNode)
-    extends RedisClientPool(node.host, node.port, node.maxIdle, node.database, node.secret, node.timeout) {
+    extends RedisClientPool(
+      node.host,
+      node.port,
+      node.maxIdle,
+      node.database,
+      node.secret,
+      node.timeout,
+      node.maxConnections,
+      node.poolWaitTimeout
+    ) {
+
     override def toString: String = node.nodename
   }
 


### PR DESCRIPTION
Optons:
- maxConnections: Int = RedisClientPool.UNLIMITED_CONNECTIONS,
- poolWaitTimeout: Long = 3000

were missing for cluster config

@debasishg do you plan to release new version soon?