### PR TITLE
fix initialization after reconnect debasishg/scala-redis#185

### DIFF
--- a/src/main/scala/com/redis/IO.scala
+++ b/src/main/scala/com/redis/IO.scala
@@ -19,6 +19,8 @@ trait IO extends Log {
     socket != null && socket.isBound && !socket.isClosed && socket.isConnected && !socket.isInputShutdown && !socket.isOutputShutdown
   }
 
+  def onConnect(): Unit
+
   // Connects the socket, and sets the input and output streams.
   def connect: Boolean = {
     try {
@@ -31,6 +33,7 @@ trait IO extends Log {
 
       out = socket.getOutputStream
       in = new BufferedInputStream(socket.getInputStream)
+      onConnect()
       true
     } catch {
       case x: Throwable =>

--- a/src/main/scala/com/redis/ds/Deque.scala
+++ b/src/main/scala/com/redis/ds/Deque.scala
@@ -84,7 +84,6 @@ class RedisDequeClient(val h: String, val p: Int, val d: Int = 0, val s: Option[
       val key = k
       override val database = d
       override val secret = s
-      initialize
 
       override def close(): Unit = disconnect
     }

--- a/src/test/scala/com/redis/RedisClientSpec.scala
+++ b/src/test/scala/com/redis/RedisClientSpec.scala
@@ -1,10 +1,15 @@
 package com.redis
 
-import java.net.URI
+import java.net.{ServerSocket, URI}
 
+import com.github.dockerjava.core.DefaultDockerClientConfig
 import com.redis.api.ApiSpec
-import org.scalatest.FunSpec
-import org.scalatest.Matchers
+import com.whisk.docker.DockerContainerManager
+import com.whisk.docker.impl.dockerjava.Docker
+import org.scalatest.{FunSpec, Matchers}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 class RedisClientSpec extends FunSpec
   with Matchers with ApiSpec {
@@ -67,4 +72,39 @@ class RedisClientSpec extends FunSpec
     r.get("vvl:qm")
     r.close()
   }}
+
+  describe("test reconnect") {
+    it("should re-init after server restart") {
+      val docker = new Docker(DefaultDockerClientConfig.createDefaultConfigBuilder().build()).client
+
+      val port = {
+        val s = new ServerSocket(0)
+        val p = s.getLocalPort
+        s.close()
+        p
+      }
+
+      val manager = new DockerContainerManager(
+        createContainer(ports = Map(redisPort -> port)) :: Nil, dockerFactory.createExecutor()
+      )
+
+      val key = "test-1"
+      val value = "test-value-1"
+
+      val (cs, _) :: _ = Await.result(manager.initReadyAll(20.seconds), 21.second)
+      val id = Await.result(cs.id, 10.seconds)
+
+      val c = new RedisClient(redisContainerHost, port, 8, timeout = 10.seconds.toMillis.toInt)
+      c.set(key, value)
+      docker.stopContainerCmd(id).exec()
+      try {c.get(key)} catch { case e: Throwable => }
+      docker.startContainerCmd(id).exec()
+      val got = c.get(key)
+      c.close()
+      docker.removeContainerCmd(id).withForce(true).withRemoveVolumes(true).exec()
+      docker.close()
+
+      got shouldBe Some(value)
+    }
+  }
 }


### PR DESCRIPTION
- fix reconnection issue 
- add test for reconnection after server is restarted

Maybe those parts of client require proper refactoring, but here's a quick fix which doesn't change api too much