### PR TITLE
Test case for fix-format-batch, demonstrating issue with keys containing single- or double-quotes

### DIFF
--- a/src/test/scala/com/redis/PipelineSpec.scala
+++ b/src/test/scala/com/redis/PipelineSpec.scala
@@ -198,6 +198,53 @@ class PipelineSpec extends AnyFunSpec
       println(res)
       res.get.size should equal(1)
     }
+
+    it("can pipeline zadd, followed by an expire, in batch") {
+      val client = new RedisClient(redisContainerHost, redisContainerPort, batch = RedisClient.BATCH)
+      val val1 = (0d, "value1")
+      val val2 = (0d, "value2")
+      val val3 = (0d, "value3")
+
+      val res = client.batchedPipeline(
+        List(
+          () => client.zadd("key1", 0d, "value0", val1, val2, val3),
+          () => client.expire("key1", 30)
+        )
+      )
+      println(res)
+      res.get.size should equal(2)
+    }
+
+    it("can pipeline zadd when the keys contain spaces, in batch") {
+      val client = new RedisClient(redisContainerHost, redisContainerPort, batch = RedisClient.BATCH)
+      val val1 = (0d, "value 1")
+      val val2 = (0d, "value 2")
+      val val3 = (0d, "valu2 3")
+
+      val res = client.batchedPipeline(
+        List(
+          () => client.zadd("key1", 0d, "value0", val1, val2, val3)
+        )
+      )
+      println(res)
+      res.get.size should equal(1)
+    }
+
+    it("can pipeline zadd when the keys contain spaces, followed by an expire, in batch") {
+      val client = new RedisClient(redisContainerHost, redisContainerPort, batch = RedisClient.BATCH)
+      val val1 = (0d, "value 1")
+      val val2 = (0d, "value 2")
+      val val3 = (0d, "valu2 3")
+
+      val res = client.batchedPipeline(
+        List(
+          () => client.zadd("key1", 0d, "value0", val1, val2, val3),
+          () => client.expire("key1", 30)
+        )
+      )
+      println(res)
+      res.get.size should equal(2)
+    }
   }
 
   describe("pipeline with batch submission with custom serialization - 1") {

--- a/src/test/scala/com/redis/PipelineSpec.scala
+++ b/src/test/scala/com/redis/PipelineSpec.scala
@@ -182,6 +182,22 @@ class PipelineSpec extends AnyFunSpec
       )
       res.get.size should equal(2)
     }
+
+    it("should handle values consisting of Kryo serialized string data") {
+      // the below are Scala strings serialized with a Kryo, a popular serialization library
+      val data1 = Array(3, 1, 45, 55, 52, 50, 51, 52, 57, 50, 57, 53, 58, 45, 49, 48, 56, 51, 48, 53, 53, 54, 52, -71)
+      val data2 = Array(3, 1, 54, 49, 56, 48, 53, 99, 49, 102, 48, 99, 56, 55, 56, 100, 49, 49, 50, 49, 101, 57, 49, 48, 99, 101, 58, 80, 73, -44)
+
+      val client = new RedisClient(redisContainerHost, redisContainerPort, batch = RedisClient.BATCH)
+
+      val res = client.batchedPipeline(
+        List(
+          () => client.lpush("key1", data1, data2)
+        )
+      )
+      println(res)
+      res.get.size should equal(1)
+    }
   }
 
   describe("pipeline with batch submission with custom serialization - 1") {


### PR DESCRIPTION
Some of our data, being capital market securities, contains single quotes. For example `Ollie's Bargain Outlet` (OLLI).

Batched Pipeline doesn't quite handle this and it fails with `ERR Protocol error: unbalanced quotes in request`